### PR TITLE
Adding dummy data to use for POC

### DIFF
--- a/docs/Presentations/D0_ProofOfConceptDemo/data/slots.json
+++ b/docs/Presentations/D0_ProofOfConceptDemo/data/slots.json
@@ -1,0 +1,10586 @@
+[
+  {
+    "slot_id": 1,
+    "field": "Field 1",
+    "calendar_day": "2025-04-28",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 2,
+    "field": "Field 1",
+    "calendar_day": "2025-04-28",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 3,
+    "field": "Field 1",
+    "calendar_day": "2025-04-28",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 4,
+    "field": "Field 1",
+    "calendar_day": "2025-04-28",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 5,
+    "field": "Field 2",
+    "calendar_day": "2025-04-28",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 6,
+    "field": "Field 2",
+    "calendar_day": "2025-04-28",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 7,
+    "field": "Field 2",
+    "calendar_day": "2025-04-28",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 8,
+    "field": "Field 2",
+    "calendar_day": "2025-04-28",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 9,
+    "field": "Field 3",
+    "calendar_day": "2025-04-28",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 10,
+    "field": "Field 3",
+    "calendar_day": "2025-04-28",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 11,
+    "field": "Field 3",
+    "calendar_day": "2025-04-28",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 12,
+    "field": "Field 3",
+    "calendar_day": "2025-04-28",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 13,
+    "field": "Field 1",
+    "calendar_day": "2025-04-29",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 14,
+    "field": "Field 1",
+    "calendar_day": "2025-04-29",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 15,
+    "field": "Field 1",
+    "calendar_day": "2025-04-29",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 16,
+    "field": "Field 1",
+    "calendar_day": "2025-04-29",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 17,
+    "field": "Field 2",
+    "calendar_day": "2025-04-29",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 18,
+    "field": "Field 2",
+    "calendar_day": "2025-04-29",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 19,
+    "field": "Field 2",
+    "calendar_day": "2025-04-29",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 20,
+    "field": "Field 2",
+    "calendar_day": "2025-04-29",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 21,
+    "field": "Field 3",
+    "calendar_day": "2025-04-29",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 22,
+    "field": "Field 3",
+    "calendar_day": "2025-04-29",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 23,
+    "field": "Field 3",
+    "calendar_day": "2025-04-29",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 24,
+    "field": "Field 3",
+    "calendar_day": "2025-04-29",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 25,
+    "field": "Field 1",
+    "calendar_day": "2025-04-30",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 26,
+    "field": "Field 1",
+    "calendar_day": "2025-04-30",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 27,
+    "field": "Field 1",
+    "calendar_day": "2025-04-30",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 28,
+    "field": "Field 1",
+    "calendar_day": "2025-04-30",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 29,
+    "field": "Field 2",
+    "calendar_day": "2025-04-30",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 30,
+    "field": "Field 2",
+    "calendar_day": "2025-04-30",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 31,
+    "field": "Field 2",
+    "calendar_day": "2025-04-30",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 32,
+    "field": "Field 2",
+    "calendar_day": "2025-04-30",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 33,
+    "field": "Field 3",
+    "calendar_day": "2025-04-30",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 34,
+    "field": "Field 3",
+    "calendar_day": "2025-04-30",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 35,
+    "field": "Field 3",
+    "calendar_day": "2025-04-30",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 36,
+    "field": "Field 3",
+    "calendar_day": "2025-04-30",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 37,
+    "field": "Field 1",
+    "calendar_day": "2025-05-01",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 38,
+    "field": "Field 1",
+    "calendar_day": "2025-05-01",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 39,
+    "field": "Field 1",
+    "calendar_day": "2025-05-01",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 40,
+    "field": "Field 1",
+    "calendar_day": "2025-05-01",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 41,
+    "field": "Field 2",
+    "calendar_day": "2025-05-01",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 42,
+    "field": "Field 2",
+    "calendar_day": "2025-05-01",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 43,
+    "field": "Field 2",
+    "calendar_day": "2025-05-01",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 44,
+    "field": "Field 2",
+    "calendar_day": "2025-05-01",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 45,
+    "field": "Field 3",
+    "calendar_day": "2025-05-01",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 46,
+    "field": "Field 3",
+    "calendar_day": "2025-05-01",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 47,
+    "field": "Field 3",
+    "calendar_day": "2025-05-01",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 48,
+    "field": "Field 3",
+    "calendar_day": "2025-05-01",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 49,
+    "field": "Field 1",
+    "calendar_day": "2025-05-02",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 50,
+    "field": "Field 1",
+    "calendar_day": "2025-05-02",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 51,
+    "field": "Field 1",
+    "calendar_day": "2025-05-02",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 52,
+    "field": "Field 1",
+    "calendar_day": "2025-05-02",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 53,
+    "field": "Field 2",
+    "calendar_day": "2025-05-02",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 54,
+    "field": "Field 2",
+    "calendar_day": "2025-05-02",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 55,
+    "field": "Field 2",
+    "calendar_day": "2025-05-02",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 56,
+    "field": "Field 2",
+    "calendar_day": "2025-05-02",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 57,
+    "field": "Field 3",
+    "calendar_day": "2025-05-02",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 58,
+    "field": "Field 3",
+    "calendar_day": "2025-05-02",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 59,
+    "field": "Field 3",
+    "calendar_day": "2025-05-02",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 60,
+    "field": "Field 3",
+    "calendar_day": "2025-05-02",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 61,
+    "field": "Field 1",
+    "calendar_day": "2025-05-03",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 62,
+    "field": "Field 1",
+    "calendar_day": "2025-05-03",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 63,
+    "field": "Field 1",
+    "calendar_day": "2025-05-03",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 64,
+    "field": "Field 1",
+    "calendar_day": "2025-05-03",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 65,
+    "field": "Field 2",
+    "calendar_day": "2025-05-03",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 66,
+    "field": "Field 2",
+    "calendar_day": "2025-05-03",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 67,
+    "field": "Field 2",
+    "calendar_day": "2025-05-03",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 68,
+    "field": "Field 2",
+    "calendar_day": "2025-05-03",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 69,
+    "field": "Field 3",
+    "calendar_day": "2025-05-03",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 70,
+    "field": "Field 3",
+    "calendar_day": "2025-05-03",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 71,
+    "field": "Field 3",
+    "calendar_day": "2025-05-03",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 72,
+    "field": "Field 3",
+    "calendar_day": "2025-05-03",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 73,
+    "field": "Field 1",
+    "calendar_day": "2025-05-04",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 74,
+    "field": "Field 1",
+    "calendar_day": "2025-05-04",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 75,
+    "field": "Field 1",
+    "calendar_day": "2025-05-04",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 76,
+    "field": "Field 1",
+    "calendar_day": "2025-05-04",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 77,
+    "field": "Field 2",
+    "calendar_day": "2025-05-04",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 78,
+    "field": "Field 2",
+    "calendar_day": "2025-05-04",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 79,
+    "field": "Field 2",
+    "calendar_day": "2025-05-04",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 80,
+    "field": "Field 2",
+    "calendar_day": "2025-05-04",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 81,
+    "field": "Field 3",
+    "calendar_day": "2025-05-04",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 82,
+    "field": "Field 3",
+    "calendar_day": "2025-05-04",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 83,
+    "field": "Field 3",
+    "calendar_day": "2025-05-04",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 84,
+    "field": "Field 3",
+    "calendar_day": "2025-05-04",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 85,
+    "field": "Field 1",
+    "calendar_day": "2025-05-05",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 86,
+    "field": "Field 1",
+    "calendar_day": "2025-05-05",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 87,
+    "field": "Field 1",
+    "calendar_day": "2025-05-05",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 88,
+    "field": "Field 1",
+    "calendar_day": "2025-05-05",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 89,
+    "field": "Field 2",
+    "calendar_day": "2025-05-05",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 90,
+    "field": "Field 2",
+    "calendar_day": "2025-05-05",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 91,
+    "field": "Field 2",
+    "calendar_day": "2025-05-05",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 92,
+    "field": "Field 2",
+    "calendar_day": "2025-05-05",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 93,
+    "field": "Field 3",
+    "calendar_day": "2025-05-05",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 94,
+    "field": "Field 3",
+    "calendar_day": "2025-05-05",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 95,
+    "field": "Field 3",
+    "calendar_day": "2025-05-05",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 96,
+    "field": "Field 3",
+    "calendar_day": "2025-05-05",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 97,
+    "field": "Field 1",
+    "calendar_day": "2025-05-06",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 98,
+    "field": "Field 1",
+    "calendar_day": "2025-05-06",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 99,
+    "field": "Field 1",
+    "calendar_day": "2025-05-06",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 100,
+    "field": "Field 1",
+    "calendar_day": "2025-05-06",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 101,
+    "field": "Field 2",
+    "calendar_day": "2025-05-06",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 102,
+    "field": "Field 2",
+    "calendar_day": "2025-05-06",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 103,
+    "field": "Field 2",
+    "calendar_day": "2025-05-06",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 104,
+    "field": "Field 2",
+    "calendar_day": "2025-05-06",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 105,
+    "field": "Field 3",
+    "calendar_day": "2025-05-06",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 106,
+    "field": "Field 3",
+    "calendar_day": "2025-05-06",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 107,
+    "field": "Field 3",
+    "calendar_day": "2025-05-06",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 108,
+    "field": "Field 3",
+    "calendar_day": "2025-05-06",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 109,
+    "field": "Field 1",
+    "calendar_day": "2025-05-07",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 110,
+    "field": "Field 1",
+    "calendar_day": "2025-05-07",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 111,
+    "field": "Field 1",
+    "calendar_day": "2025-05-07",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 112,
+    "field": "Field 1",
+    "calendar_day": "2025-05-07",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 113,
+    "field": "Field 2",
+    "calendar_day": "2025-05-07",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 114,
+    "field": "Field 2",
+    "calendar_day": "2025-05-07",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 115,
+    "field": "Field 2",
+    "calendar_day": "2025-05-07",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 116,
+    "field": "Field 2",
+    "calendar_day": "2025-05-07",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 117,
+    "field": "Field 3",
+    "calendar_day": "2025-05-07",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 118,
+    "field": "Field 3",
+    "calendar_day": "2025-05-07",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 119,
+    "field": "Field 3",
+    "calendar_day": "2025-05-07",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 120,
+    "field": "Field 3",
+    "calendar_day": "2025-05-07",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 121,
+    "field": "Field 1",
+    "calendar_day": "2025-05-08",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 122,
+    "field": "Field 1",
+    "calendar_day": "2025-05-08",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 123,
+    "field": "Field 1",
+    "calendar_day": "2025-05-08",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 124,
+    "field": "Field 1",
+    "calendar_day": "2025-05-08",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 125,
+    "field": "Field 2",
+    "calendar_day": "2025-05-08",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 126,
+    "field": "Field 2",
+    "calendar_day": "2025-05-08",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 127,
+    "field": "Field 2",
+    "calendar_day": "2025-05-08",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 128,
+    "field": "Field 2",
+    "calendar_day": "2025-05-08",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 129,
+    "field": "Field 3",
+    "calendar_day": "2025-05-08",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 130,
+    "field": "Field 3",
+    "calendar_day": "2025-05-08",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 131,
+    "field": "Field 3",
+    "calendar_day": "2025-05-08",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 132,
+    "field": "Field 3",
+    "calendar_day": "2025-05-08",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 133,
+    "field": "Field 1",
+    "calendar_day": "2025-05-09",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 134,
+    "field": "Field 1",
+    "calendar_day": "2025-05-09",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 135,
+    "field": "Field 1",
+    "calendar_day": "2025-05-09",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 136,
+    "field": "Field 1",
+    "calendar_day": "2025-05-09",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 137,
+    "field": "Field 2",
+    "calendar_day": "2025-05-09",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 138,
+    "field": "Field 2",
+    "calendar_day": "2025-05-09",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 139,
+    "field": "Field 2",
+    "calendar_day": "2025-05-09",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 140,
+    "field": "Field 2",
+    "calendar_day": "2025-05-09",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 141,
+    "field": "Field 3",
+    "calendar_day": "2025-05-09",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 142,
+    "field": "Field 3",
+    "calendar_day": "2025-05-09",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 143,
+    "field": "Field 3",
+    "calendar_day": "2025-05-09",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 144,
+    "field": "Field 3",
+    "calendar_day": "2025-05-09",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 145,
+    "field": "Field 1",
+    "calendar_day": "2025-05-10",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 146,
+    "field": "Field 1",
+    "calendar_day": "2025-05-10",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 147,
+    "field": "Field 1",
+    "calendar_day": "2025-05-10",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 148,
+    "field": "Field 1",
+    "calendar_day": "2025-05-10",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 149,
+    "field": "Field 2",
+    "calendar_day": "2025-05-10",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 150,
+    "field": "Field 2",
+    "calendar_day": "2025-05-10",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 151,
+    "field": "Field 2",
+    "calendar_day": "2025-05-10",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 152,
+    "field": "Field 2",
+    "calendar_day": "2025-05-10",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 153,
+    "field": "Field 3",
+    "calendar_day": "2025-05-10",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 154,
+    "field": "Field 3",
+    "calendar_day": "2025-05-10",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 155,
+    "field": "Field 3",
+    "calendar_day": "2025-05-10",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 156,
+    "field": "Field 3",
+    "calendar_day": "2025-05-10",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 157,
+    "field": "Field 1",
+    "calendar_day": "2025-05-11",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 158,
+    "field": "Field 1",
+    "calendar_day": "2025-05-11",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 159,
+    "field": "Field 1",
+    "calendar_day": "2025-05-11",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 160,
+    "field": "Field 1",
+    "calendar_day": "2025-05-11",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 161,
+    "field": "Field 2",
+    "calendar_day": "2025-05-11",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 162,
+    "field": "Field 2",
+    "calendar_day": "2025-05-11",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 163,
+    "field": "Field 2",
+    "calendar_day": "2025-05-11",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 164,
+    "field": "Field 2",
+    "calendar_day": "2025-05-11",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 165,
+    "field": "Field 3",
+    "calendar_day": "2025-05-11",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 166,
+    "field": "Field 3",
+    "calendar_day": "2025-05-11",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 167,
+    "field": "Field 3",
+    "calendar_day": "2025-05-11",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 168,
+    "field": "Field 3",
+    "calendar_day": "2025-05-11",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 169,
+    "field": "Field 1",
+    "calendar_day": "2025-05-12",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 170,
+    "field": "Field 1",
+    "calendar_day": "2025-05-12",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 171,
+    "field": "Field 1",
+    "calendar_day": "2025-05-12",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 172,
+    "field": "Field 1",
+    "calendar_day": "2025-05-12",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 173,
+    "field": "Field 2",
+    "calendar_day": "2025-05-12",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 174,
+    "field": "Field 2",
+    "calendar_day": "2025-05-12",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 175,
+    "field": "Field 2",
+    "calendar_day": "2025-05-12",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 176,
+    "field": "Field 2",
+    "calendar_day": "2025-05-12",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 177,
+    "field": "Field 3",
+    "calendar_day": "2025-05-12",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 178,
+    "field": "Field 3",
+    "calendar_day": "2025-05-12",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 179,
+    "field": "Field 3",
+    "calendar_day": "2025-05-12",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 180,
+    "field": "Field 3",
+    "calendar_day": "2025-05-12",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 181,
+    "field": "Field 1",
+    "calendar_day": "2025-05-13",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 182,
+    "field": "Field 1",
+    "calendar_day": "2025-05-13",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 183,
+    "field": "Field 1",
+    "calendar_day": "2025-05-13",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 184,
+    "field": "Field 1",
+    "calendar_day": "2025-05-13",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 185,
+    "field": "Field 2",
+    "calendar_day": "2025-05-13",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 186,
+    "field": "Field 2",
+    "calendar_day": "2025-05-13",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 187,
+    "field": "Field 2",
+    "calendar_day": "2025-05-13",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 188,
+    "field": "Field 2",
+    "calendar_day": "2025-05-13",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 189,
+    "field": "Field 3",
+    "calendar_day": "2025-05-13",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 190,
+    "field": "Field 3",
+    "calendar_day": "2025-05-13",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 191,
+    "field": "Field 3",
+    "calendar_day": "2025-05-13",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 192,
+    "field": "Field 3",
+    "calendar_day": "2025-05-13",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 193,
+    "field": "Field 1",
+    "calendar_day": "2025-05-14",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 194,
+    "field": "Field 1",
+    "calendar_day": "2025-05-14",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 195,
+    "field": "Field 1",
+    "calendar_day": "2025-05-14",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 196,
+    "field": "Field 1",
+    "calendar_day": "2025-05-14",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 197,
+    "field": "Field 2",
+    "calendar_day": "2025-05-14",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 198,
+    "field": "Field 2",
+    "calendar_day": "2025-05-14",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 199,
+    "field": "Field 2",
+    "calendar_day": "2025-05-14",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 200,
+    "field": "Field 2",
+    "calendar_day": "2025-05-14",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 201,
+    "field": "Field 3",
+    "calendar_day": "2025-05-14",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 202,
+    "field": "Field 3",
+    "calendar_day": "2025-05-14",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 203,
+    "field": "Field 3",
+    "calendar_day": "2025-05-14",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 204,
+    "field": "Field 3",
+    "calendar_day": "2025-05-14",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 205,
+    "field": "Field 1",
+    "calendar_day": "2025-05-15",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 206,
+    "field": "Field 1",
+    "calendar_day": "2025-05-15",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 207,
+    "field": "Field 1",
+    "calendar_day": "2025-05-15",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 208,
+    "field": "Field 1",
+    "calendar_day": "2025-05-15",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 209,
+    "field": "Field 2",
+    "calendar_day": "2025-05-15",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 210,
+    "field": "Field 2",
+    "calendar_day": "2025-05-15",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 211,
+    "field": "Field 2",
+    "calendar_day": "2025-05-15",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 212,
+    "field": "Field 2",
+    "calendar_day": "2025-05-15",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 213,
+    "field": "Field 3",
+    "calendar_day": "2025-05-15",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 214,
+    "field": "Field 3",
+    "calendar_day": "2025-05-15",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 215,
+    "field": "Field 3",
+    "calendar_day": "2025-05-15",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 216,
+    "field": "Field 3",
+    "calendar_day": "2025-05-15",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 217,
+    "field": "Field 1",
+    "calendar_day": "2025-05-16",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 218,
+    "field": "Field 1",
+    "calendar_day": "2025-05-16",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 219,
+    "field": "Field 1",
+    "calendar_day": "2025-05-16",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 220,
+    "field": "Field 1",
+    "calendar_day": "2025-05-16",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 221,
+    "field": "Field 2",
+    "calendar_day": "2025-05-16",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 222,
+    "field": "Field 2",
+    "calendar_day": "2025-05-16",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 223,
+    "field": "Field 2",
+    "calendar_day": "2025-05-16",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 224,
+    "field": "Field 2",
+    "calendar_day": "2025-05-16",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 225,
+    "field": "Field 3",
+    "calendar_day": "2025-05-16",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 226,
+    "field": "Field 3",
+    "calendar_day": "2025-05-16",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 227,
+    "field": "Field 3",
+    "calendar_day": "2025-05-16",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 228,
+    "field": "Field 3",
+    "calendar_day": "2025-05-16",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 229,
+    "field": "Field 1",
+    "calendar_day": "2025-05-17",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 230,
+    "field": "Field 1",
+    "calendar_day": "2025-05-17",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 231,
+    "field": "Field 1",
+    "calendar_day": "2025-05-17",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 232,
+    "field": "Field 1",
+    "calendar_day": "2025-05-17",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 233,
+    "field": "Field 2",
+    "calendar_day": "2025-05-17",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 234,
+    "field": "Field 2",
+    "calendar_day": "2025-05-17",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 235,
+    "field": "Field 2",
+    "calendar_day": "2025-05-17",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 236,
+    "field": "Field 2",
+    "calendar_day": "2025-05-17",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 237,
+    "field": "Field 3",
+    "calendar_day": "2025-05-17",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 238,
+    "field": "Field 3",
+    "calendar_day": "2025-05-17",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 239,
+    "field": "Field 3",
+    "calendar_day": "2025-05-17",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 240,
+    "field": "Field 3",
+    "calendar_day": "2025-05-17",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 241,
+    "field": "Field 1",
+    "calendar_day": "2025-05-18",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 242,
+    "field": "Field 1",
+    "calendar_day": "2025-05-18",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 243,
+    "field": "Field 1",
+    "calendar_day": "2025-05-18",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 244,
+    "field": "Field 1",
+    "calendar_day": "2025-05-18",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 245,
+    "field": "Field 2",
+    "calendar_day": "2025-05-18",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 246,
+    "field": "Field 2",
+    "calendar_day": "2025-05-18",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 247,
+    "field": "Field 2",
+    "calendar_day": "2025-05-18",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 248,
+    "field": "Field 2",
+    "calendar_day": "2025-05-18",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 249,
+    "field": "Field 3",
+    "calendar_day": "2025-05-18",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 250,
+    "field": "Field 3",
+    "calendar_day": "2025-05-18",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 251,
+    "field": "Field 3",
+    "calendar_day": "2025-05-18",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 252,
+    "field": "Field 3",
+    "calendar_day": "2025-05-18",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 253,
+    "field": "Field 1",
+    "calendar_day": "2025-05-19",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 254,
+    "field": "Field 1",
+    "calendar_day": "2025-05-19",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 255,
+    "field": "Field 1",
+    "calendar_day": "2025-05-19",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 256,
+    "field": "Field 1",
+    "calendar_day": "2025-05-19",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 257,
+    "field": "Field 2",
+    "calendar_day": "2025-05-19",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 258,
+    "field": "Field 2",
+    "calendar_day": "2025-05-19",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 259,
+    "field": "Field 2",
+    "calendar_day": "2025-05-19",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 260,
+    "field": "Field 2",
+    "calendar_day": "2025-05-19",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 261,
+    "field": "Field 3",
+    "calendar_day": "2025-05-19",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 262,
+    "field": "Field 3",
+    "calendar_day": "2025-05-19",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 263,
+    "field": "Field 3",
+    "calendar_day": "2025-05-19",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 264,
+    "field": "Field 3",
+    "calendar_day": "2025-05-19",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 265,
+    "field": "Field 1",
+    "calendar_day": "2025-05-20",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 266,
+    "field": "Field 1",
+    "calendar_day": "2025-05-20",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 267,
+    "field": "Field 1",
+    "calendar_day": "2025-05-20",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 268,
+    "field": "Field 1",
+    "calendar_day": "2025-05-20",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 269,
+    "field": "Field 2",
+    "calendar_day": "2025-05-20",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 270,
+    "field": "Field 2",
+    "calendar_day": "2025-05-20",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 271,
+    "field": "Field 2",
+    "calendar_day": "2025-05-20",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 272,
+    "field": "Field 2",
+    "calendar_day": "2025-05-20",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 273,
+    "field": "Field 3",
+    "calendar_day": "2025-05-20",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 274,
+    "field": "Field 3",
+    "calendar_day": "2025-05-20",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 275,
+    "field": "Field 3",
+    "calendar_day": "2025-05-20",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 276,
+    "field": "Field 3",
+    "calendar_day": "2025-05-20",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 277,
+    "field": "Field 1",
+    "calendar_day": "2025-05-21",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 278,
+    "field": "Field 1",
+    "calendar_day": "2025-05-21",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 279,
+    "field": "Field 1",
+    "calendar_day": "2025-05-21",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 280,
+    "field": "Field 1",
+    "calendar_day": "2025-05-21",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 281,
+    "field": "Field 2",
+    "calendar_day": "2025-05-21",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 282,
+    "field": "Field 2",
+    "calendar_day": "2025-05-21",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 283,
+    "field": "Field 2",
+    "calendar_day": "2025-05-21",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 284,
+    "field": "Field 2",
+    "calendar_day": "2025-05-21",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 285,
+    "field": "Field 3",
+    "calendar_day": "2025-05-21",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 286,
+    "field": "Field 3",
+    "calendar_day": "2025-05-21",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 287,
+    "field": "Field 3",
+    "calendar_day": "2025-05-21",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 288,
+    "field": "Field 3",
+    "calendar_day": "2025-05-21",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 289,
+    "field": "Field 1",
+    "calendar_day": "2025-05-22",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 290,
+    "field": "Field 1",
+    "calendar_day": "2025-05-22",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 291,
+    "field": "Field 1",
+    "calendar_day": "2025-05-22",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 292,
+    "field": "Field 1",
+    "calendar_day": "2025-05-22",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 293,
+    "field": "Field 2",
+    "calendar_day": "2025-05-22",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 294,
+    "field": "Field 2",
+    "calendar_day": "2025-05-22",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 295,
+    "field": "Field 2",
+    "calendar_day": "2025-05-22",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 296,
+    "field": "Field 2",
+    "calendar_day": "2025-05-22",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 297,
+    "field": "Field 3",
+    "calendar_day": "2025-05-22",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 298,
+    "field": "Field 3",
+    "calendar_day": "2025-05-22",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 299,
+    "field": "Field 3",
+    "calendar_day": "2025-05-22",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 300,
+    "field": "Field 3",
+    "calendar_day": "2025-05-22",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 301,
+    "field": "Field 1",
+    "calendar_day": "2025-05-23",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 302,
+    "field": "Field 1",
+    "calendar_day": "2025-05-23",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 303,
+    "field": "Field 1",
+    "calendar_day": "2025-05-23",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 304,
+    "field": "Field 1",
+    "calendar_day": "2025-05-23",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 305,
+    "field": "Field 2",
+    "calendar_day": "2025-05-23",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 306,
+    "field": "Field 2",
+    "calendar_day": "2025-05-23",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 307,
+    "field": "Field 2",
+    "calendar_day": "2025-05-23",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 308,
+    "field": "Field 2",
+    "calendar_day": "2025-05-23",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 309,
+    "field": "Field 3",
+    "calendar_day": "2025-05-23",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 310,
+    "field": "Field 3",
+    "calendar_day": "2025-05-23",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 311,
+    "field": "Field 3",
+    "calendar_day": "2025-05-23",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 312,
+    "field": "Field 3",
+    "calendar_day": "2025-05-23",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 313,
+    "field": "Field 1",
+    "calendar_day": "2025-05-24",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 314,
+    "field": "Field 1",
+    "calendar_day": "2025-05-24",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 315,
+    "field": "Field 1",
+    "calendar_day": "2025-05-24",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 316,
+    "field": "Field 1",
+    "calendar_day": "2025-05-24",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 317,
+    "field": "Field 2",
+    "calendar_day": "2025-05-24",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 318,
+    "field": "Field 2",
+    "calendar_day": "2025-05-24",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 319,
+    "field": "Field 2",
+    "calendar_day": "2025-05-24",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 320,
+    "field": "Field 2",
+    "calendar_day": "2025-05-24",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 321,
+    "field": "Field 3",
+    "calendar_day": "2025-05-24",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 322,
+    "field": "Field 3",
+    "calendar_day": "2025-05-24",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 323,
+    "field": "Field 3",
+    "calendar_day": "2025-05-24",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 324,
+    "field": "Field 3",
+    "calendar_day": "2025-05-24",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 325,
+    "field": "Field 1",
+    "calendar_day": "2025-05-25",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 326,
+    "field": "Field 1",
+    "calendar_day": "2025-05-25",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 327,
+    "field": "Field 1",
+    "calendar_day": "2025-05-25",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 328,
+    "field": "Field 1",
+    "calendar_day": "2025-05-25",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 329,
+    "field": "Field 2",
+    "calendar_day": "2025-05-25",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 330,
+    "field": "Field 2",
+    "calendar_day": "2025-05-25",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 331,
+    "field": "Field 2",
+    "calendar_day": "2025-05-25",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 332,
+    "field": "Field 2",
+    "calendar_day": "2025-05-25",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 333,
+    "field": "Field 3",
+    "calendar_day": "2025-05-25",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 334,
+    "field": "Field 3",
+    "calendar_day": "2025-05-25",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 335,
+    "field": "Field 3",
+    "calendar_day": "2025-05-25",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 336,
+    "field": "Field 3",
+    "calendar_day": "2025-05-25",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 337,
+    "field": "Field 1",
+    "calendar_day": "2025-05-26",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 338,
+    "field": "Field 1",
+    "calendar_day": "2025-05-26",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 339,
+    "field": "Field 1",
+    "calendar_day": "2025-05-26",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 340,
+    "field": "Field 1",
+    "calendar_day": "2025-05-26",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 341,
+    "field": "Field 2",
+    "calendar_day": "2025-05-26",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 342,
+    "field": "Field 2",
+    "calendar_day": "2025-05-26",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 343,
+    "field": "Field 2",
+    "calendar_day": "2025-05-26",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 344,
+    "field": "Field 2",
+    "calendar_day": "2025-05-26",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 345,
+    "field": "Field 3",
+    "calendar_day": "2025-05-26",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 346,
+    "field": "Field 3",
+    "calendar_day": "2025-05-26",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 347,
+    "field": "Field 3",
+    "calendar_day": "2025-05-26",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 348,
+    "field": "Field 3",
+    "calendar_day": "2025-05-26",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 349,
+    "field": "Field 1",
+    "calendar_day": "2025-05-27",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 350,
+    "field": "Field 1",
+    "calendar_day": "2025-05-27",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 351,
+    "field": "Field 1",
+    "calendar_day": "2025-05-27",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 352,
+    "field": "Field 1",
+    "calendar_day": "2025-05-27",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 353,
+    "field": "Field 2",
+    "calendar_day": "2025-05-27",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 354,
+    "field": "Field 2",
+    "calendar_day": "2025-05-27",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 355,
+    "field": "Field 2",
+    "calendar_day": "2025-05-27",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 356,
+    "field": "Field 2",
+    "calendar_day": "2025-05-27",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 357,
+    "field": "Field 3",
+    "calendar_day": "2025-05-27",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 358,
+    "field": "Field 3",
+    "calendar_day": "2025-05-27",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 359,
+    "field": "Field 3",
+    "calendar_day": "2025-05-27",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 360,
+    "field": "Field 3",
+    "calendar_day": "2025-05-27",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 361,
+    "field": "Field 1",
+    "calendar_day": "2025-05-28",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 362,
+    "field": "Field 1",
+    "calendar_day": "2025-05-28",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 363,
+    "field": "Field 1",
+    "calendar_day": "2025-05-28",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 364,
+    "field": "Field 1",
+    "calendar_day": "2025-05-28",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 365,
+    "field": "Field 2",
+    "calendar_day": "2025-05-28",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 366,
+    "field": "Field 2",
+    "calendar_day": "2025-05-28",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 367,
+    "field": "Field 2",
+    "calendar_day": "2025-05-28",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 368,
+    "field": "Field 2",
+    "calendar_day": "2025-05-28",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 369,
+    "field": "Field 3",
+    "calendar_day": "2025-05-28",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 370,
+    "field": "Field 3",
+    "calendar_day": "2025-05-28",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 371,
+    "field": "Field 3",
+    "calendar_day": "2025-05-28",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 372,
+    "field": "Field 3",
+    "calendar_day": "2025-05-28",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 373,
+    "field": "Field 1",
+    "calendar_day": "2025-05-29",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 374,
+    "field": "Field 1",
+    "calendar_day": "2025-05-29",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 375,
+    "field": "Field 1",
+    "calendar_day": "2025-05-29",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 376,
+    "field": "Field 1",
+    "calendar_day": "2025-05-29",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 377,
+    "field": "Field 2",
+    "calendar_day": "2025-05-29",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 378,
+    "field": "Field 2",
+    "calendar_day": "2025-05-29",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 379,
+    "field": "Field 2",
+    "calendar_day": "2025-05-29",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 380,
+    "field": "Field 2",
+    "calendar_day": "2025-05-29",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 381,
+    "field": "Field 3",
+    "calendar_day": "2025-05-29",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 382,
+    "field": "Field 3",
+    "calendar_day": "2025-05-29",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 383,
+    "field": "Field 3",
+    "calendar_day": "2025-05-29",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 384,
+    "field": "Field 3",
+    "calendar_day": "2025-05-29",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 385,
+    "field": "Field 1",
+    "calendar_day": "2025-05-30",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 386,
+    "field": "Field 1",
+    "calendar_day": "2025-05-30",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 387,
+    "field": "Field 1",
+    "calendar_day": "2025-05-30",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 388,
+    "field": "Field 1",
+    "calendar_day": "2025-05-30",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 389,
+    "field": "Field 2",
+    "calendar_day": "2025-05-30",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 390,
+    "field": "Field 2",
+    "calendar_day": "2025-05-30",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 391,
+    "field": "Field 2",
+    "calendar_day": "2025-05-30",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 392,
+    "field": "Field 2",
+    "calendar_day": "2025-05-30",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 393,
+    "field": "Field 3",
+    "calendar_day": "2025-05-30",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 394,
+    "field": "Field 3",
+    "calendar_day": "2025-05-30",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 395,
+    "field": "Field 3",
+    "calendar_day": "2025-05-30",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 396,
+    "field": "Field 3",
+    "calendar_day": "2025-05-30",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 397,
+    "field": "Field 1",
+    "calendar_day": "2025-05-31",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 398,
+    "field": "Field 1",
+    "calendar_day": "2025-05-31",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 399,
+    "field": "Field 1",
+    "calendar_day": "2025-05-31",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 400,
+    "field": "Field 1",
+    "calendar_day": "2025-05-31",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 401,
+    "field": "Field 2",
+    "calendar_day": "2025-05-31",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 402,
+    "field": "Field 2",
+    "calendar_day": "2025-05-31",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 403,
+    "field": "Field 2",
+    "calendar_day": "2025-05-31",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 404,
+    "field": "Field 2",
+    "calendar_day": "2025-05-31",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 405,
+    "field": "Field 3",
+    "calendar_day": "2025-05-31",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 406,
+    "field": "Field 3",
+    "calendar_day": "2025-05-31",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 407,
+    "field": "Field 3",
+    "calendar_day": "2025-05-31",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 408,
+    "field": "Field 3",
+    "calendar_day": "2025-05-31",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 409,
+    "field": "Field 1",
+    "calendar_day": "2025-06-01",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 410,
+    "field": "Field 1",
+    "calendar_day": "2025-06-01",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 411,
+    "field": "Field 1",
+    "calendar_day": "2025-06-01",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 412,
+    "field": "Field 1",
+    "calendar_day": "2025-06-01",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 413,
+    "field": "Field 2",
+    "calendar_day": "2025-06-01",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 414,
+    "field": "Field 2",
+    "calendar_day": "2025-06-01",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 415,
+    "field": "Field 2",
+    "calendar_day": "2025-06-01",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 416,
+    "field": "Field 2",
+    "calendar_day": "2025-06-01",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 417,
+    "field": "Field 3",
+    "calendar_day": "2025-06-01",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 418,
+    "field": "Field 3",
+    "calendar_day": "2025-06-01",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 419,
+    "field": "Field 3",
+    "calendar_day": "2025-06-01",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 420,
+    "field": "Field 3",
+    "calendar_day": "2025-06-01",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 421,
+    "field": "Field 1",
+    "calendar_day": "2025-06-02",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 422,
+    "field": "Field 1",
+    "calendar_day": "2025-06-02",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 423,
+    "field": "Field 1",
+    "calendar_day": "2025-06-02",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 424,
+    "field": "Field 1",
+    "calendar_day": "2025-06-02",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 425,
+    "field": "Field 2",
+    "calendar_day": "2025-06-02",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 426,
+    "field": "Field 2",
+    "calendar_day": "2025-06-02",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 427,
+    "field": "Field 2",
+    "calendar_day": "2025-06-02",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 428,
+    "field": "Field 2",
+    "calendar_day": "2025-06-02",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 429,
+    "field": "Field 3",
+    "calendar_day": "2025-06-02",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 430,
+    "field": "Field 3",
+    "calendar_day": "2025-06-02",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 431,
+    "field": "Field 3",
+    "calendar_day": "2025-06-02",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 432,
+    "field": "Field 3",
+    "calendar_day": "2025-06-02",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 433,
+    "field": "Field 1",
+    "calendar_day": "2025-06-03",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 434,
+    "field": "Field 1",
+    "calendar_day": "2025-06-03",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 435,
+    "field": "Field 1",
+    "calendar_day": "2025-06-03",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 436,
+    "field": "Field 1",
+    "calendar_day": "2025-06-03",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 437,
+    "field": "Field 2",
+    "calendar_day": "2025-06-03",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 438,
+    "field": "Field 2",
+    "calendar_day": "2025-06-03",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 439,
+    "field": "Field 2",
+    "calendar_day": "2025-06-03",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 440,
+    "field": "Field 2",
+    "calendar_day": "2025-06-03",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 441,
+    "field": "Field 3",
+    "calendar_day": "2025-06-03",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 442,
+    "field": "Field 3",
+    "calendar_day": "2025-06-03",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 443,
+    "field": "Field 3",
+    "calendar_day": "2025-06-03",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 444,
+    "field": "Field 3",
+    "calendar_day": "2025-06-03",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 445,
+    "field": "Field 1",
+    "calendar_day": "2025-06-04",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 446,
+    "field": "Field 1",
+    "calendar_day": "2025-06-04",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 447,
+    "field": "Field 1",
+    "calendar_day": "2025-06-04",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 448,
+    "field": "Field 1",
+    "calendar_day": "2025-06-04",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 449,
+    "field": "Field 2",
+    "calendar_day": "2025-06-04",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 450,
+    "field": "Field 2",
+    "calendar_day": "2025-06-04",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 451,
+    "field": "Field 2",
+    "calendar_day": "2025-06-04",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 452,
+    "field": "Field 2",
+    "calendar_day": "2025-06-04",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 453,
+    "field": "Field 3",
+    "calendar_day": "2025-06-04",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 454,
+    "field": "Field 3",
+    "calendar_day": "2025-06-04",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 455,
+    "field": "Field 3",
+    "calendar_day": "2025-06-04",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 456,
+    "field": "Field 3",
+    "calendar_day": "2025-06-04",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 457,
+    "field": "Field 1",
+    "calendar_day": "2025-06-05",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 458,
+    "field": "Field 1",
+    "calendar_day": "2025-06-05",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 459,
+    "field": "Field 1",
+    "calendar_day": "2025-06-05",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 460,
+    "field": "Field 1",
+    "calendar_day": "2025-06-05",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 461,
+    "field": "Field 2",
+    "calendar_day": "2025-06-05",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 462,
+    "field": "Field 2",
+    "calendar_day": "2025-06-05",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 463,
+    "field": "Field 2",
+    "calendar_day": "2025-06-05",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 464,
+    "field": "Field 2",
+    "calendar_day": "2025-06-05",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 465,
+    "field": "Field 3",
+    "calendar_day": "2025-06-05",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 466,
+    "field": "Field 3",
+    "calendar_day": "2025-06-05",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 467,
+    "field": "Field 3",
+    "calendar_day": "2025-06-05",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 468,
+    "field": "Field 3",
+    "calendar_day": "2025-06-05",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 469,
+    "field": "Field 1",
+    "calendar_day": "2025-06-06",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 470,
+    "field": "Field 1",
+    "calendar_day": "2025-06-06",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 471,
+    "field": "Field 1",
+    "calendar_day": "2025-06-06",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 472,
+    "field": "Field 1",
+    "calendar_day": "2025-06-06",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 473,
+    "field": "Field 2",
+    "calendar_day": "2025-06-06",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 474,
+    "field": "Field 2",
+    "calendar_day": "2025-06-06",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 475,
+    "field": "Field 2",
+    "calendar_day": "2025-06-06",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 476,
+    "field": "Field 2",
+    "calendar_day": "2025-06-06",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 477,
+    "field": "Field 3",
+    "calendar_day": "2025-06-06",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 478,
+    "field": "Field 3",
+    "calendar_day": "2025-06-06",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 479,
+    "field": "Field 3",
+    "calendar_day": "2025-06-06",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 480,
+    "field": "Field 3",
+    "calendar_day": "2025-06-06",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 481,
+    "field": "Field 1",
+    "calendar_day": "2025-06-07",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 482,
+    "field": "Field 1",
+    "calendar_day": "2025-06-07",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 483,
+    "field": "Field 1",
+    "calendar_day": "2025-06-07",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 484,
+    "field": "Field 1",
+    "calendar_day": "2025-06-07",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 485,
+    "field": "Field 2",
+    "calendar_day": "2025-06-07",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 486,
+    "field": "Field 2",
+    "calendar_day": "2025-06-07",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 487,
+    "field": "Field 2",
+    "calendar_day": "2025-06-07",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 488,
+    "field": "Field 2",
+    "calendar_day": "2025-06-07",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 489,
+    "field": "Field 3",
+    "calendar_day": "2025-06-07",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 490,
+    "field": "Field 3",
+    "calendar_day": "2025-06-07",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 491,
+    "field": "Field 3",
+    "calendar_day": "2025-06-07",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 492,
+    "field": "Field 3",
+    "calendar_day": "2025-06-07",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 493,
+    "field": "Field 1",
+    "calendar_day": "2025-06-08",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 494,
+    "field": "Field 1",
+    "calendar_day": "2025-06-08",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 495,
+    "field": "Field 1",
+    "calendar_day": "2025-06-08",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 496,
+    "field": "Field 1",
+    "calendar_day": "2025-06-08",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 497,
+    "field": "Field 2",
+    "calendar_day": "2025-06-08",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 498,
+    "field": "Field 2",
+    "calendar_day": "2025-06-08",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 499,
+    "field": "Field 2",
+    "calendar_day": "2025-06-08",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 500,
+    "field": "Field 2",
+    "calendar_day": "2025-06-08",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 501,
+    "field": "Field 3",
+    "calendar_day": "2025-06-08",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 502,
+    "field": "Field 3",
+    "calendar_day": "2025-06-08",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 503,
+    "field": "Field 3",
+    "calendar_day": "2025-06-08",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 504,
+    "field": "Field 3",
+    "calendar_day": "2025-06-08",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 505,
+    "field": "Field 1",
+    "calendar_day": "2025-06-09",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 506,
+    "field": "Field 1",
+    "calendar_day": "2025-06-09",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 507,
+    "field": "Field 1",
+    "calendar_day": "2025-06-09",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 508,
+    "field": "Field 1",
+    "calendar_day": "2025-06-09",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 509,
+    "field": "Field 2",
+    "calendar_day": "2025-06-09",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 510,
+    "field": "Field 2",
+    "calendar_day": "2025-06-09",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 511,
+    "field": "Field 2",
+    "calendar_day": "2025-06-09",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 512,
+    "field": "Field 2",
+    "calendar_day": "2025-06-09",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 513,
+    "field": "Field 3",
+    "calendar_day": "2025-06-09",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 514,
+    "field": "Field 3",
+    "calendar_day": "2025-06-09",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 515,
+    "field": "Field 3",
+    "calendar_day": "2025-06-09",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 516,
+    "field": "Field 3",
+    "calendar_day": "2025-06-09",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 517,
+    "field": "Field 1",
+    "calendar_day": "2025-06-10",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 518,
+    "field": "Field 1",
+    "calendar_day": "2025-06-10",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 519,
+    "field": "Field 1",
+    "calendar_day": "2025-06-10",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 520,
+    "field": "Field 1",
+    "calendar_day": "2025-06-10",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 521,
+    "field": "Field 2",
+    "calendar_day": "2025-06-10",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 522,
+    "field": "Field 2",
+    "calendar_day": "2025-06-10",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 523,
+    "field": "Field 2",
+    "calendar_day": "2025-06-10",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 524,
+    "field": "Field 2",
+    "calendar_day": "2025-06-10",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 525,
+    "field": "Field 3",
+    "calendar_day": "2025-06-10",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 526,
+    "field": "Field 3",
+    "calendar_day": "2025-06-10",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 527,
+    "field": "Field 3",
+    "calendar_day": "2025-06-10",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 528,
+    "field": "Field 3",
+    "calendar_day": "2025-06-10",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 529,
+    "field": "Field 1",
+    "calendar_day": "2025-06-11",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 530,
+    "field": "Field 1",
+    "calendar_day": "2025-06-11",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 531,
+    "field": "Field 1",
+    "calendar_day": "2025-06-11",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 532,
+    "field": "Field 1",
+    "calendar_day": "2025-06-11",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 533,
+    "field": "Field 2",
+    "calendar_day": "2025-06-11",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 534,
+    "field": "Field 2",
+    "calendar_day": "2025-06-11",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 535,
+    "field": "Field 2",
+    "calendar_day": "2025-06-11",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 536,
+    "field": "Field 2",
+    "calendar_day": "2025-06-11",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 537,
+    "field": "Field 3",
+    "calendar_day": "2025-06-11",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 538,
+    "field": "Field 3",
+    "calendar_day": "2025-06-11",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 539,
+    "field": "Field 3",
+    "calendar_day": "2025-06-11",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 540,
+    "field": "Field 3",
+    "calendar_day": "2025-06-11",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 541,
+    "field": "Field 1",
+    "calendar_day": "2025-06-12",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 542,
+    "field": "Field 1",
+    "calendar_day": "2025-06-12",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 543,
+    "field": "Field 1",
+    "calendar_day": "2025-06-12",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 544,
+    "field": "Field 1",
+    "calendar_day": "2025-06-12",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 545,
+    "field": "Field 2",
+    "calendar_day": "2025-06-12",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 546,
+    "field": "Field 2",
+    "calendar_day": "2025-06-12",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 547,
+    "field": "Field 2",
+    "calendar_day": "2025-06-12",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 548,
+    "field": "Field 2",
+    "calendar_day": "2025-06-12",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 549,
+    "field": "Field 3",
+    "calendar_day": "2025-06-12",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 550,
+    "field": "Field 3",
+    "calendar_day": "2025-06-12",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 551,
+    "field": "Field 3",
+    "calendar_day": "2025-06-12",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 552,
+    "field": "Field 3",
+    "calendar_day": "2025-06-12",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 553,
+    "field": "Field 1",
+    "calendar_day": "2025-06-13",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 554,
+    "field": "Field 1",
+    "calendar_day": "2025-06-13",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 555,
+    "field": "Field 1",
+    "calendar_day": "2025-06-13",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 556,
+    "field": "Field 1",
+    "calendar_day": "2025-06-13",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 557,
+    "field": "Field 2",
+    "calendar_day": "2025-06-13",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 558,
+    "field": "Field 2",
+    "calendar_day": "2025-06-13",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 559,
+    "field": "Field 2",
+    "calendar_day": "2025-06-13",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 560,
+    "field": "Field 2",
+    "calendar_day": "2025-06-13",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 561,
+    "field": "Field 3",
+    "calendar_day": "2025-06-13",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 562,
+    "field": "Field 3",
+    "calendar_day": "2025-06-13",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 563,
+    "field": "Field 3",
+    "calendar_day": "2025-06-13",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 564,
+    "field": "Field 3",
+    "calendar_day": "2025-06-13",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 565,
+    "field": "Field 1",
+    "calendar_day": "2025-06-14",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 566,
+    "field": "Field 1",
+    "calendar_day": "2025-06-14",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 567,
+    "field": "Field 1",
+    "calendar_day": "2025-06-14",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 568,
+    "field": "Field 1",
+    "calendar_day": "2025-06-14",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 569,
+    "field": "Field 2",
+    "calendar_day": "2025-06-14",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 570,
+    "field": "Field 2",
+    "calendar_day": "2025-06-14",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 571,
+    "field": "Field 2",
+    "calendar_day": "2025-06-14",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 572,
+    "field": "Field 2",
+    "calendar_day": "2025-06-14",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 573,
+    "field": "Field 3",
+    "calendar_day": "2025-06-14",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 574,
+    "field": "Field 3",
+    "calendar_day": "2025-06-14",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 575,
+    "field": "Field 3",
+    "calendar_day": "2025-06-14",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 576,
+    "field": "Field 3",
+    "calendar_day": "2025-06-14",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 577,
+    "field": "Field 1",
+    "calendar_day": "2025-06-15",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 578,
+    "field": "Field 1",
+    "calendar_day": "2025-06-15",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 579,
+    "field": "Field 1",
+    "calendar_day": "2025-06-15",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 580,
+    "field": "Field 1",
+    "calendar_day": "2025-06-15",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 581,
+    "field": "Field 2",
+    "calendar_day": "2025-06-15",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 582,
+    "field": "Field 2",
+    "calendar_day": "2025-06-15",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 583,
+    "field": "Field 2",
+    "calendar_day": "2025-06-15",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 584,
+    "field": "Field 2",
+    "calendar_day": "2025-06-15",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 585,
+    "field": "Field 3",
+    "calendar_day": "2025-06-15",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 586,
+    "field": "Field 3",
+    "calendar_day": "2025-06-15",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 587,
+    "field": "Field 3",
+    "calendar_day": "2025-06-15",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 588,
+    "field": "Field 3",
+    "calendar_day": "2025-06-15",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 589,
+    "field": "Field 1",
+    "calendar_day": "2025-06-16",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 590,
+    "field": "Field 1",
+    "calendar_day": "2025-06-16",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 591,
+    "field": "Field 1",
+    "calendar_day": "2025-06-16",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 592,
+    "field": "Field 1",
+    "calendar_day": "2025-06-16",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 593,
+    "field": "Field 2",
+    "calendar_day": "2025-06-16",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 594,
+    "field": "Field 2",
+    "calendar_day": "2025-06-16",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 595,
+    "field": "Field 2",
+    "calendar_day": "2025-06-16",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 596,
+    "field": "Field 2",
+    "calendar_day": "2025-06-16",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 597,
+    "field": "Field 3",
+    "calendar_day": "2025-06-16",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 598,
+    "field": "Field 3",
+    "calendar_day": "2025-06-16",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 599,
+    "field": "Field 3",
+    "calendar_day": "2025-06-16",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 600,
+    "field": "Field 3",
+    "calendar_day": "2025-06-16",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 601,
+    "field": "Field 1",
+    "calendar_day": "2025-06-17",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 602,
+    "field": "Field 1",
+    "calendar_day": "2025-06-17",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 603,
+    "field": "Field 1",
+    "calendar_day": "2025-06-17",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 604,
+    "field": "Field 1",
+    "calendar_day": "2025-06-17",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 605,
+    "field": "Field 2",
+    "calendar_day": "2025-06-17",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 606,
+    "field": "Field 2",
+    "calendar_day": "2025-06-17",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 607,
+    "field": "Field 2",
+    "calendar_day": "2025-06-17",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 608,
+    "field": "Field 2",
+    "calendar_day": "2025-06-17",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 609,
+    "field": "Field 3",
+    "calendar_day": "2025-06-17",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 610,
+    "field": "Field 3",
+    "calendar_day": "2025-06-17",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 611,
+    "field": "Field 3",
+    "calendar_day": "2025-06-17",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 612,
+    "field": "Field 3",
+    "calendar_day": "2025-06-17",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 613,
+    "field": "Field 1",
+    "calendar_day": "2025-06-18",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 614,
+    "field": "Field 1",
+    "calendar_day": "2025-06-18",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 615,
+    "field": "Field 1",
+    "calendar_day": "2025-06-18",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 616,
+    "field": "Field 1",
+    "calendar_day": "2025-06-18",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 617,
+    "field": "Field 2",
+    "calendar_day": "2025-06-18",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 618,
+    "field": "Field 2",
+    "calendar_day": "2025-06-18",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 619,
+    "field": "Field 2",
+    "calendar_day": "2025-06-18",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 620,
+    "field": "Field 2",
+    "calendar_day": "2025-06-18",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 621,
+    "field": "Field 3",
+    "calendar_day": "2025-06-18",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 622,
+    "field": "Field 3",
+    "calendar_day": "2025-06-18",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 623,
+    "field": "Field 3",
+    "calendar_day": "2025-06-18",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 624,
+    "field": "Field 3",
+    "calendar_day": "2025-06-18",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 625,
+    "field": "Field 1",
+    "calendar_day": "2025-06-19",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 626,
+    "field": "Field 1",
+    "calendar_day": "2025-06-19",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 627,
+    "field": "Field 1",
+    "calendar_day": "2025-06-19",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 628,
+    "field": "Field 1",
+    "calendar_day": "2025-06-19",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 629,
+    "field": "Field 2",
+    "calendar_day": "2025-06-19",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 630,
+    "field": "Field 2",
+    "calendar_day": "2025-06-19",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 631,
+    "field": "Field 2",
+    "calendar_day": "2025-06-19",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 632,
+    "field": "Field 2",
+    "calendar_day": "2025-06-19",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 633,
+    "field": "Field 3",
+    "calendar_day": "2025-06-19",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 634,
+    "field": "Field 3",
+    "calendar_day": "2025-06-19",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 635,
+    "field": "Field 3",
+    "calendar_day": "2025-06-19",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 636,
+    "field": "Field 3",
+    "calendar_day": "2025-06-19",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 637,
+    "field": "Field 1",
+    "calendar_day": "2025-06-20",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 638,
+    "field": "Field 1",
+    "calendar_day": "2025-06-20",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 639,
+    "field": "Field 1",
+    "calendar_day": "2025-06-20",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 640,
+    "field": "Field 1",
+    "calendar_day": "2025-06-20",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 641,
+    "field": "Field 2",
+    "calendar_day": "2025-06-20",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 642,
+    "field": "Field 2",
+    "calendar_day": "2025-06-20",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 643,
+    "field": "Field 2",
+    "calendar_day": "2025-06-20",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 644,
+    "field": "Field 2",
+    "calendar_day": "2025-06-20",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 645,
+    "field": "Field 3",
+    "calendar_day": "2025-06-20",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 646,
+    "field": "Field 3",
+    "calendar_day": "2025-06-20",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 647,
+    "field": "Field 3",
+    "calendar_day": "2025-06-20",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 648,
+    "field": "Field 3",
+    "calendar_day": "2025-06-20",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 649,
+    "field": "Field 1",
+    "calendar_day": "2025-06-21",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 650,
+    "field": "Field 1",
+    "calendar_day": "2025-06-21",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 651,
+    "field": "Field 1",
+    "calendar_day": "2025-06-21",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 652,
+    "field": "Field 1",
+    "calendar_day": "2025-06-21",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 653,
+    "field": "Field 2",
+    "calendar_day": "2025-06-21",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 654,
+    "field": "Field 2",
+    "calendar_day": "2025-06-21",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 655,
+    "field": "Field 2",
+    "calendar_day": "2025-06-21",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 656,
+    "field": "Field 2",
+    "calendar_day": "2025-06-21",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 657,
+    "field": "Field 3",
+    "calendar_day": "2025-06-21",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 658,
+    "field": "Field 3",
+    "calendar_day": "2025-06-21",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 659,
+    "field": "Field 3",
+    "calendar_day": "2025-06-21",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 660,
+    "field": "Field 3",
+    "calendar_day": "2025-06-21",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 661,
+    "field": "Field 1",
+    "calendar_day": "2025-06-22",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 662,
+    "field": "Field 1",
+    "calendar_day": "2025-06-22",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 663,
+    "field": "Field 1",
+    "calendar_day": "2025-06-22",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 664,
+    "field": "Field 1",
+    "calendar_day": "2025-06-22",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 665,
+    "field": "Field 2",
+    "calendar_day": "2025-06-22",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 666,
+    "field": "Field 2",
+    "calendar_day": "2025-06-22",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 667,
+    "field": "Field 2",
+    "calendar_day": "2025-06-22",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 668,
+    "field": "Field 2",
+    "calendar_day": "2025-06-22",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 669,
+    "field": "Field 3",
+    "calendar_day": "2025-06-22",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 670,
+    "field": "Field 3",
+    "calendar_day": "2025-06-22",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 671,
+    "field": "Field 3",
+    "calendar_day": "2025-06-22",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 672,
+    "field": "Field 3",
+    "calendar_day": "2025-06-22",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 673,
+    "field": "Field 1",
+    "calendar_day": "2025-06-23",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 674,
+    "field": "Field 1",
+    "calendar_day": "2025-06-23",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 675,
+    "field": "Field 1",
+    "calendar_day": "2025-06-23",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 676,
+    "field": "Field 1",
+    "calendar_day": "2025-06-23",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 677,
+    "field": "Field 2",
+    "calendar_day": "2025-06-23",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 678,
+    "field": "Field 2",
+    "calendar_day": "2025-06-23",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 679,
+    "field": "Field 2",
+    "calendar_day": "2025-06-23",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 680,
+    "field": "Field 2",
+    "calendar_day": "2025-06-23",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 681,
+    "field": "Field 3",
+    "calendar_day": "2025-06-23",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 682,
+    "field": "Field 3",
+    "calendar_day": "2025-06-23",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 683,
+    "field": "Field 3",
+    "calendar_day": "2025-06-23",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 684,
+    "field": "Field 3",
+    "calendar_day": "2025-06-23",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 685,
+    "field": "Field 1",
+    "calendar_day": "2025-06-24",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 686,
+    "field": "Field 1",
+    "calendar_day": "2025-06-24",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 687,
+    "field": "Field 1",
+    "calendar_day": "2025-06-24",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 688,
+    "field": "Field 1",
+    "calendar_day": "2025-06-24",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 689,
+    "field": "Field 2",
+    "calendar_day": "2025-06-24",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 690,
+    "field": "Field 2",
+    "calendar_day": "2025-06-24",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 691,
+    "field": "Field 2",
+    "calendar_day": "2025-06-24",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 692,
+    "field": "Field 2",
+    "calendar_day": "2025-06-24",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 693,
+    "field": "Field 3",
+    "calendar_day": "2025-06-24",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 694,
+    "field": "Field 3",
+    "calendar_day": "2025-06-24",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 695,
+    "field": "Field 3",
+    "calendar_day": "2025-06-24",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 696,
+    "field": "Field 3",
+    "calendar_day": "2025-06-24",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 697,
+    "field": "Field 1",
+    "calendar_day": "2025-06-25",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 698,
+    "field": "Field 1",
+    "calendar_day": "2025-06-25",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 699,
+    "field": "Field 1",
+    "calendar_day": "2025-06-25",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 700,
+    "field": "Field 1",
+    "calendar_day": "2025-06-25",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 701,
+    "field": "Field 2",
+    "calendar_day": "2025-06-25",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 702,
+    "field": "Field 2",
+    "calendar_day": "2025-06-25",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 703,
+    "field": "Field 2",
+    "calendar_day": "2025-06-25",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 704,
+    "field": "Field 2",
+    "calendar_day": "2025-06-25",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 705,
+    "field": "Field 3",
+    "calendar_day": "2025-06-25",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 706,
+    "field": "Field 3",
+    "calendar_day": "2025-06-25",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 707,
+    "field": "Field 3",
+    "calendar_day": "2025-06-25",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 708,
+    "field": "Field 3",
+    "calendar_day": "2025-06-25",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 709,
+    "field": "Field 1",
+    "calendar_day": "2025-06-26",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 710,
+    "field": "Field 1",
+    "calendar_day": "2025-06-26",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 711,
+    "field": "Field 1",
+    "calendar_day": "2025-06-26",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 712,
+    "field": "Field 1",
+    "calendar_day": "2025-06-26",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 713,
+    "field": "Field 2",
+    "calendar_day": "2025-06-26",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 714,
+    "field": "Field 2",
+    "calendar_day": "2025-06-26",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 715,
+    "field": "Field 2",
+    "calendar_day": "2025-06-26",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 716,
+    "field": "Field 2",
+    "calendar_day": "2025-06-26",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 717,
+    "field": "Field 3",
+    "calendar_day": "2025-06-26",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 718,
+    "field": "Field 3",
+    "calendar_day": "2025-06-26",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 719,
+    "field": "Field 3",
+    "calendar_day": "2025-06-26",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 720,
+    "field": "Field 3",
+    "calendar_day": "2025-06-26",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 721,
+    "field": "Field 1",
+    "calendar_day": "2025-06-27",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 722,
+    "field": "Field 1",
+    "calendar_day": "2025-06-27",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 723,
+    "field": "Field 1",
+    "calendar_day": "2025-06-27",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 724,
+    "field": "Field 1",
+    "calendar_day": "2025-06-27",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 725,
+    "field": "Field 2",
+    "calendar_day": "2025-06-27",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 726,
+    "field": "Field 2",
+    "calendar_day": "2025-06-27",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 727,
+    "field": "Field 2",
+    "calendar_day": "2025-06-27",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 728,
+    "field": "Field 2",
+    "calendar_day": "2025-06-27",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 729,
+    "field": "Field 3",
+    "calendar_day": "2025-06-27",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 730,
+    "field": "Field 3",
+    "calendar_day": "2025-06-27",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 731,
+    "field": "Field 3",
+    "calendar_day": "2025-06-27",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 732,
+    "field": "Field 3",
+    "calendar_day": "2025-06-27",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 733,
+    "field": "Field 1",
+    "calendar_day": "2025-06-28",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 734,
+    "field": "Field 1",
+    "calendar_day": "2025-06-28",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 735,
+    "field": "Field 1",
+    "calendar_day": "2025-06-28",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 736,
+    "field": "Field 1",
+    "calendar_day": "2025-06-28",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 737,
+    "field": "Field 2",
+    "calendar_day": "2025-06-28",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 738,
+    "field": "Field 2",
+    "calendar_day": "2025-06-28",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 739,
+    "field": "Field 2",
+    "calendar_day": "2025-06-28",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 740,
+    "field": "Field 2",
+    "calendar_day": "2025-06-28",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 741,
+    "field": "Field 3",
+    "calendar_day": "2025-06-28",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 742,
+    "field": "Field 3",
+    "calendar_day": "2025-06-28",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 743,
+    "field": "Field 3",
+    "calendar_day": "2025-06-28",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 744,
+    "field": "Field 3",
+    "calendar_day": "2025-06-28",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 745,
+    "field": "Field 1",
+    "calendar_day": "2025-06-29",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 746,
+    "field": "Field 1",
+    "calendar_day": "2025-06-29",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 747,
+    "field": "Field 1",
+    "calendar_day": "2025-06-29",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 748,
+    "field": "Field 1",
+    "calendar_day": "2025-06-29",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 749,
+    "field": "Field 2",
+    "calendar_day": "2025-06-29",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 750,
+    "field": "Field 2",
+    "calendar_day": "2025-06-29",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 751,
+    "field": "Field 2",
+    "calendar_day": "2025-06-29",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 752,
+    "field": "Field 2",
+    "calendar_day": "2025-06-29",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 753,
+    "field": "Field 3",
+    "calendar_day": "2025-06-29",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 754,
+    "field": "Field 3",
+    "calendar_day": "2025-06-29",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 755,
+    "field": "Field 3",
+    "calendar_day": "2025-06-29",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 756,
+    "field": "Field 3",
+    "calendar_day": "2025-06-29",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 757,
+    "field": "Field 1",
+    "calendar_day": "2025-06-30",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 758,
+    "field": "Field 1",
+    "calendar_day": "2025-06-30",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 759,
+    "field": "Field 1",
+    "calendar_day": "2025-06-30",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 760,
+    "field": "Field 1",
+    "calendar_day": "2025-06-30",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 761,
+    "field": "Field 2",
+    "calendar_day": "2025-06-30",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 762,
+    "field": "Field 2",
+    "calendar_day": "2025-06-30",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 763,
+    "field": "Field 2",
+    "calendar_day": "2025-06-30",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 764,
+    "field": "Field 2",
+    "calendar_day": "2025-06-30",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 765,
+    "field": "Field 3",
+    "calendar_day": "2025-06-30",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 766,
+    "field": "Field 3",
+    "calendar_day": "2025-06-30",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 767,
+    "field": "Field 3",
+    "calendar_day": "2025-06-30",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 768,
+    "field": "Field 3",
+    "calendar_day": "2025-06-30",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 769,
+    "field": "Field 1",
+    "calendar_day": "2025-07-01",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 770,
+    "field": "Field 1",
+    "calendar_day": "2025-07-01",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 771,
+    "field": "Field 1",
+    "calendar_day": "2025-07-01",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 772,
+    "field": "Field 1",
+    "calendar_day": "2025-07-01",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 773,
+    "field": "Field 2",
+    "calendar_day": "2025-07-01",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 774,
+    "field": "Field 2",
+    "calendar_day": "2025-07-01",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 775,
+    "field": "Field 2",
+    "calendar_day": "2025-07-01",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 776,
+    "field": "Field 2",
+    "calendar_day": "2025-07-01",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 777,
+    "field": "Field 3",
+    "calendar_day": "2025-07-01",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 778,
+    "field": "Field 3",
+    "calendar_day": "2025-07-01",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 779,
+    "field": "Field 3",
+    "calendar_day": "2025-07-01",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 780,
+    "field": "Field 3",
+    "calendar_day": "2025-07-01",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 781,
+    "field": "Field 1",
+    "calendar_day": "2025-07-02",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 782,
+    "field": "Field 1",
+    "calendar_day": "2025-07-02",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 783,
+    "field": "Field 1",
+    "calendar_day": "2025-07-02",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 784,
+    "field": "Field 1",
+    "calendar_day": "2025-07-02",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 785,
+    "field": "Field 2",
+    "calendar_day": "2025-07-02",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 786,
+    "field": "Field 2",
+    "calendar_day": "2025-07-02",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 787,
+    "field": "Field 2",
+    "calendar_day": "2025-07-02",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 788,
+    "field": "Field 2",
+    "calendar_day": "2025-07-02",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 789,
+    "field": "Field 3",
+    "calendar_day": "2025-07-02",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 790,
+    "field": "Field 3",
+    "calendar_day": "2025-07-02",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 791,
+    "field": "Field 3",
+    "calendar_day": "2025-07-02",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 792,
+    "field": "Field 3",
+    "calendar_day": "2025-07-02",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 793,
+    "field": "Field 1",
+    "calendar_day": "2025-07-03",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 794,
+    "field": "Field 1",
+    "calendar_day": "2025-07-03",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 795,
+    "field": "Field 1",
+    "calendar_day": "2025-07-03",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 796,
+    "field": "Field 1",
+    "calendar_day": "2025-07-03",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 797,
+    "field": "Field 2",
+    "calendar_day": "2025-07-03",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 798,
+    "field": "Field 2",
+    "calendar_day": "2025-07-03",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 799,
+    "field": "Field 2",
+    "calendar_day": "2025-07-03",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 800,
+    "field": "Field 2",
+    "calendar_day": "2025-07-03",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 801,
+    "field": "Field 3",
+    "calendar_day": "2025-07-03",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 802,
+    "field": "Field 3",
+    "calendar_day": "2025-07-03",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 803,
+    "field": "Field 3",
+    "calendar_day": "2025-07-03",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 804,
+    "field": "Field 3",
+    "calendar_day": "2025-07-03",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 805,
+    "field": "Field 1",
+    "calendar_day": "2025-07-04",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 806,
+    "field": "Field 1",
+    "calendar_day": "2025-07-04",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 807,
+    "field": "Field 1",
+    "calendar_day": "2025-07-04",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 808,
+    "field": "Field 1",
+    "calendar_day": "2025-07-04",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 809,
+    "field": "Field 2",
+    "calendar_day": "2025-07-04",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 810,
+    "field": "Field 2",
+    "calendar_day": "2025-07-04",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 811,
+    "field": "Field 2",
+    "calendar_day": "2025-07-04",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 812,
+    "field": "Field 2",
+    "calendar_day": "2025-07-04",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 813,
+    "field": "Field 3",
+    "calendar_day": "2025-07-04",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 814,
+    "field": "Field 3",
+    "calendar_day": "2025-07-04",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 815,
+    "field": "Field 3",
+    "calendar_day": "2025-07-04",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 816,
+    "field": "Field 3",
+    "calendar_day": "2025-07-04",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 817,
+    "field": "Field 1",
+    "calendar_day": "2025-07-05",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 818,
+    "field": "Field 1",
+    "calendar_day": "2025-07-05",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 819,
+    "field": "Field 1",
+    "calendar_day": "2025-07-05",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 820,
+    "field": "Field 1",
+    "calendar_day": "2025-07-05",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 821,
+    "field": "Field 2",
+    "calendar_day": "2025-07-05",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 822,
+    "field": "Field 2",
+    "calendar_day": "2025-07-05",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 823,
+    "field": "Field 2",
+    "calendar_day": "2025-07-05",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 824,
+    "field": "Field 2",
+    "calendar_day": "2025-07-05",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 825,
+    "field": "Field 3",
+    "calendar_day": "2025-07-05",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 826,
+    "field": "Field 3",
+    "calendar_day": "2025-07-05",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 827,
+    "field": "Field 3",
+    "calendar_day": "2025-07-05",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 828,
+    "field": "Field 3",
+    "calendar_day": "2025-07-05",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 829,
+    "field": "Field 1",
+    "calendar_day": "2025-07-06",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 830,
+    "field": "Field 1",
+    "calendar_day": "2025-07-06",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 831,
+    "field": "Field 1",
+    "calendar_day": "2025-07-06",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 832,
+    "field": "Field 1",
+    "calendar_day": "2025-07-06",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 833,
+    "field": "Field 2",
+    "calendar_day": "2025-07-06",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 834,
+    "field": "Field 2",
+    "calendar_day": "2025-07-06",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 835,
+    "field": "Field 2",
+    "calendar_day": "2025-07-06",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 836,
+    "field": "Field 2",
+    "calendar_day": "2025-07-06",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 837,
+    "field": "Field 3",
+    "calendar_day": "2025-07-06",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 838,
+    "field": "Field 3",
+    "calendar_day": "2025-07-06",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 839,
+    "field": "Field 3",
+    "calendar_day": "2025-07-06",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 840,
+    "field": "Field 3",
+    "calendar_day": "2025-07-06",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 841,
+    "field": "Field 1",
+    "calendar_day": "2025-07-07",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 842,
+    "field": "Field 1",
+    "calendar_day": "2025-07-07",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 843,
+    "field": "Field 1",
+    "calendar_day": "2025-07-07",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 844,
+    "field": "Field 1",
+    "calendar_day": "2025-07-07",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 845,
+    "field": "Field 2",
+    "calendar_day": "2025-07-07",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 846,
+    "field": "Field 2",
+    "calendar_day": "2025-07-07",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 847,
+    "field": "Field 2",
+    "calendar_day": "2025-07-07",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 848,
+    "field": "Field 2",
+    "calendar_day": "2025-07-07",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 849,
+    "field": "Field 3",
+    "calendar_day": "2025-07-07",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 850,
+    "field": "Field 3",
+    "calendar_day": "2025-07-07",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 851,
+    "field": "Field 3",
+    "calendar_day": "2025-07-07",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 852,
+    "field": "Field 3",
+    "calendar_day": "2025-07-07",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 853,
+    "field": "Field 1",
+    "calendar_day": "2025-07-08",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 854,
+    "field": "Field 1",
+    "calendar_day": "2025-07-08",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 855,
+    "field": "Field 1",
+    "calendar_day": "2025-07-08",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 856,
+    "field": "Field 1",
+    "calendar_day": "2025-07-08",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 857,
+    "field": "Field 2",
+    "calendar_day": "2025-07-08",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 858,
+    "field": "Field 2",
+    "calendar_day": "2025-07-08",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 859,
+    "field": "Field 2",
+    "calendar_day": "2025-07-08",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 860,
+    "field": "Field 2",
+    "calendar_day": "2025-07-08",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 861,
+    "field": "Field 3",
+    "calendar_day": "2025-07-08",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 862,
+    "field": "Field 3",
+    "calendar_day": "2025-07-08",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 863,
+    "field": "Field 3",
+    "calendar_day": "2025-07-08",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 864,
+    "field": "Field 3",
+    "calendar_day": "2025-07-08",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 865,
+    "field": "Field 1",
+    "calendar_day": "2025-07-09",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 866,
+    "field": "Field 1",
+    "calendar_day": "2025-07-09",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 867,
+    "field": "Field 1",
+    "calendar_day": "2025-07-09",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 868,
+    "field": "Field 1",
+    "calendar_day": "2025-07-09",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 869,
+    "field": "Field 2",
+    "calendar_day": "2025-07-09",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 870,
+    "field": "Field 2",
+    "calendar_day": "2025-07-09",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 871,
+    "field": "Field 2",
+    "calendar_day": "2025-07-09",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 872,
+    "field": "Field 2",
+    "calendar_day": "2025-07-09",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 873,
+    "field": "Field 3",
+    "calendar_day": "2025-07-09",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 874,
+    "field": "Field 3",
+    "calendar_day": "2025-07-09",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 875,
+    "field": "Field 3",
+    "calendar_day": "2025-07-09",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 876,
+    "field": "Field 3",
+    "calendar_day": "2025-07-09",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 877,
+    "field": "Field 1",
+    "calendar_day": "2025-07-10",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 878,
+    "field": "Field 1",
+    "calendar_day": "2025-07-10",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 879,
+    "field": "Field 1",
+    "calendar_day": "2025-07-10",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 880,
+    "field": "Field 1",
+    "calendar_day": "2025-07-10",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 881,
+    "field": "Field 2",
+    "calendar_day": "2025-07-10",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 882,
+    "field": "Field 2",
+    "calendar_day": "2025-07-10",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 883,
+    "field": "Field 2",
+    "calendar_day": "2025-07-10",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 884,
+    "field": "Field 2",
+    "calendar_day": "2025-07-10",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 885,
+    "field": "Field 3",
+    "calendar_day": "2025-07-10",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 886,
+    "field": "Field 3",
+    "calendar_day": "2025-07-10",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 887,
+    "field": "Field 3",
+    "calendar_day": "2025-07-10",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 888,
+    "field": "Field 3",
+    "calendar_day": "2025-07-10",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 889,
+    "field": "Field 1",
+    "calendar_day": "2025-07-11",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 890,
+    "field": "Field 1",
+    "calendar_day": "2025-07-11",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 891,
+    "field": "Field 1",
+    "calendar_day": "2025-07-11",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 892,
+    "field": "Field 1",
+    "calendar_day": "2025-07-11",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 893,
+    "field": "Field 2",
+    "calendar_day": "2025-07-11",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 894,
+    "field": "Field 2",
+    "calendar_day": "2025-07-11",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 895,
+    "field": "Field 2",
+    "calendar_day": "2025-07-11",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 896,
+    "field": "Field 2",
+    "calendar_day": "2025-07-11",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 897,
+    "field": "Field 3",
+    "calendar_day": "2025-07-11",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 898,
+    "field": "Field 3",
+    "calendar_day": "2025-07-11",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 899,
+    "field": "Field 3",
+    "calendar_day": "2025-07-11",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 900,
+    "field": "Field 3",
+    "calendar_day": "2025-07-11",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 901,
+    "field": "Field 1",
+    "calendar_day": "2025-07-12",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 902,
+    "field": "Field 1",
+    "calendar_day": "2025-07-12",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 903,
+    "field": "Field 1",
+    "calendar_day": "2025-07-12",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 904,
+    "field": "Field 1",
+    "calendar_day": "2025-07-12",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 905,
+    "field": "Field 2",
+    "calendar_day": "2025-07-12",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 906,
+    "field": "Field 2",
+    "calendar_day": "2025-07-12",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 907,
+    "field": "Field 2",
+    "calendar_day": "2025-07-12",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 908,
+    "field": "Field 2",
+    "calendar_day": "2025-07-12",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 909,
+    "field": "Field 3",
+    "calendar_day": "2025-07-12",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 910,
+    "field": "Field 3",
+    "calendar_day": "2025-07-12",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 911,
+    "field": "Field 3",
+    "calendar_day": "2025-07-12",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 912,
+    "field": "Field 3",
+    "calendar_day": "2025-07-12",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 913,
+    "field": "Field 1",
+    "calendar_day": "2025-07-13",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 914,
+    "field": "Field 1",
+    "calendar_day": "2025-07-13",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 915,
+    "field": "Field 1",
+    "calendar_day": "2025-07-13",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 916,
+    "field": "Field 1",
+    "calendar_day": "2025-07-13",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 917,
+    "field": "Field 2",
+    "calendar_day": "2025-07-13",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 918,
+    "field": "Field 2",
+    "calendar_day": "2025-07-13",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 919,
+    "field": "Field 2",
+    "calendar_day": "2025-07-13",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 920,
+    "field": "Field 2",
+    "calendar_day": "2025-07-13",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 921,
+    "field": "Field 3",
+    "calendar_day": "2025-07-13",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 922,
+    "field": "Field 3",
+    "calendar_day": "2025-07-13",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 923,
+    "field": "Field 3",
+    "calendar_day": "2025-07-13",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 924,
+    "field": "Field 3",
+    "calendar_day": "2025-07-13",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 925,
+    "field": "Field 1",
+    "calendar_day": "2025-07-14",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 926,
+    "field": "Field 1",
+    "calendar_day": "2025-07-14",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 927,
+    "field": "Field 1",
+    "calendar_day": "2025-07-14",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 928,
+    "field": "Field 1",
+    "calendar_day": "2025-07-14",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 929,
+    "field": "Field 2",
+    "calendar_day": "2025-07-14",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 930,
+    "field": "Field 2",
+    "calendar_day": "2025-07-14",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 931,
+    "field": "Field 2",
+    "calendar_day": "2025-07-14",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 932,
+    "field": "Field 2",
+    "calendar_day": "2025-07-14",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 933,
+    "field": "Field 3",
+    "calendar_day": "2025-07-14",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 934,
+    "field": "Field 3",
+    "calendar_day": "2025-07-14",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 935,
+    "field": "Field 3",
+    "calendar_day": "2025-07-14",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 936,
+    "field": "Field 3",
+    "calendar_day": "2025-07-14",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 937,
+    "field": "Field 1",
+    "calendar_day": "2025-07-15",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 938,
+    "field": "Field 1",
+    "calendar_day": "2025-07-15",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 939,
+    "field": "Field 1",
+    "calendar_day": "2025-07-15",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 940,
+    "field": "Field 1",
+    "calendar_day": "2025-07-15",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 941,
+    "field": "Field 2",
+    "calendar_day": "2025-07-15",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 942,
+    "field": "Field 2",
+    "calendar_day": "2025-07-15",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 943,
+    "field": "Field 2",
+    "calendar_day": "2025-07-15",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 944,
+    "field": "Field 2",
+    "calendar_day": "2025-07-15",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 945,
+    "field": "Field 3",
+    "calendar_day": "2025-07-15",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 946,
+    "field": "Field 3",
+    "calendar_day": "2025-07-15",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 947,
+    "field": "Field 3",
+    "calendar_day": "2025-07-15",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 948,
+    "field": "Field 3",
+    "calendar_day": "2025-07-15",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 949,
+    "field": "Field 1",
+    "calendar_day": "2025-07-16",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 950,
+    "field": "Field 1",
+    "calendar_day": "2025-07-16",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 951,
+    "field": "Field 1",
+    "calendar_day": "2025-07-16",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 952,
+    "field": "Field 1",
+    "calendar_day": "2025-07-16",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 953,
+    "field": "Field 2",
+    "calendar_day": "2025-07-16",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 954,
+    "field": "Field 2",
+    "calendar_day": "2025-07-16",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 955,
+    "field": "Field 2",
+    "calendar_day": "2025-07-16",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 956,
+    "field": "Field 2",
+    "calendar_day": "2025-07-16",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 957,
+    "field": "Field 3",
+    "calendar_day": "2025-07-16",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 958,
+    "field": "Field 3",
+    "calendar_day": "2025-07-16",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 959,
+    "field": "Field 3",
+    "calendar_day": "2025-07-16",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 960,
+    "field": "Field 3",
+    "calendar_day": "2025-07-16",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 961,
+    "field": "Field 1",
+    "calendar_day": "2025-07-17",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 962,
+    "field": "Field 1",
+    "calendar_day": "2025-07-17",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 963,
+    "field": "Field 1",
+    "calendar_day": "2025-07-17",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 964,
+    "field": "Field 1",
+    "calendar_day": "2025-07-17",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 965,
+    "field": "Field 2",
+    "calendar_day": "2025-07-17",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 966,
+    "field": "Field 2",
+    "calendar_day": "2025-07-17",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 967,
+    "field": "Field 2",
+    "calendar_day": "2025-07-17",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 968,
+    "field": "Field 2",
+    "calendar_day": "2025-07-17",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 969,
+    "field": "Field 3",
+    "calendar_day": "2025-07-17",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 970,
+    "field": "Field 3",
+    "calendar_day": "2025-07-17",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 971,
+    "field": "Field 3",
+    "calendar_day": "2025-07-17",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 972,
+    "field": "Field 3",
+    "calendar_day": "2025-07-17",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 973,
+    "field": "Field 1",
+    "calendar_day": "2025-07-18",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 974,
+    "field": "Field 1",
+    "calendar_day": "2025-07-18",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 975,
+    "field": "Field 1",
+    "calendar_day": "2025-07-18",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 976,
+    "field": "Field 1",
+    "calendar_day": "2025-07-18",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 977,
+    "field": "Field 2",
+    "calendar_day": "2025-07-18",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 978,
+    "field": "Field 2",
+    "calendar_day": "2025-07-18",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 979,
+    "field": "Field 2",
+    "calendar_day": "2025-07-18",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 980,
+    "field": "Field 2",
+    "calendar_day": "2025-07-18",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 981,
+    "field": "Field 3",
+    "calendar_day": "2025-07-18",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 982,
+    "field": "Field 3",
+    "calendar_day": "2025-07-18",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 983,
+    "field": "Field 3",
+    "calendar_day": "2025-07-18",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 984,
+    "field": "Field 3",
+    "calendar_day": "2025-07-18",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 985,
+    "field": "Field 1",
+    "calendar_day": "2025-07-19",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 986,
+    "field": "Field 1",
+    "calendar_day": "2025-07-19",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 987,
+    "field": "Field 1",
+    "calendar_day": "2025-07-19",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 988,
+    "field": "Field 1",
+    "calendar_day": "2025-07-19",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 989,
+    "field": "Field 2",
+    "calendar_day": "2025-07-19",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 990,
+    "field": "Field 2",
+    "calendar_day": "2025-07-19",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 991,
+    "field": "Field 2",
+    "calendar_day": "2025-07-19",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 992,
+    "field": "Field 2",
+    "calendar_day": "2025-07-19",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 993,
+    "field": "Field 3",
+    "calendar_day": "2025-07-19",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 994,
+    "field": "Field 3",
+    "calendar_day": "2025-07-19",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 995,
+    "field": "Field 3",
+    "calendar_day": "2025-07-19",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 996,
+    "field": "Field 3",
+    "calendar_day": "2025-07-19",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 997,
+    "field": "Field 1",
+    "calendar_day": "2025-07-20",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 998,
+    "field": "Field 1",
+    "calendar_day": "2025-07-20",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 999,
+    "field": "Field 1",
+    "calendar_day": "2025-07-20",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1000,
+    "field": "Field 1",
+    "calendar_day": "2025-07-20",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1001,
+    "field": "Field 2",
+    "calendar_day": "2025-07-20",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1002,
+    "field": "Field 2",
+    "calendar_day": "2025-07-20",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1003,
+    "field": "Field 2",
+    "calendar_day": "2025-07-20",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1004,
+    "field": "Field 2",
+    "calendar_day": "2025-07-20",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1005,
+    "field": "Field 3",
+    "calendar_day": "2025-07-20",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1006,
+    "field": "Field 3",
+    "calendar_day": "2025-07-20",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1007,
+    "field": "Field 3",
+    "calendar_day": "2025-07-20",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1008,
+    "field": "Field 3",
+    "calendar_day": "2025-07-20",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1009,
+    "field": "Field 1",
+    "calendar_day": "2025-07-21",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1010,
+    "field": "Field 1",
+    "calendar_day": "2025-07-21",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1011,
+    "field": "Field 1",
+    "calendar_day": "2025-07-21",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1012,
+    "field": "Field 1",
+    "calendar_day": "2025-07-21",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1013,
+    "field": "Field 2",
+    "calendar_day": "2025-07-21",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1014,
+    "field": "Field 2",
+    "calendar_day": "2025-07-21",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1015,
+    "field": "Field 2",
+    "calendar_day": "2025-07-21",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1016,
+    "field": "Field 2",
+    "calendar_day": "2025-07-21",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1017,
+    "field": "Field 3",
+    "calendar_day": "2025-07-21",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1018,
+    "field": "Field 3",
+    "calendar_day": "2025-07-21",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1019,
+    "field": "Field 3",
+    "calendar_day": "2025-07-21",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1020,
+    "field": "Field 3",
+    "calendar_day": "2025-07-21",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1021,
+    "field": "Field 1",
+    "calendar_day": "2025-07-22",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1022,
+    "field": "Field 1",
+    "calendar_day": "2025-07-22",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1023,
+    "field": "Field 1",
+    "calendar_day": "2025-07-22",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1024,
+    "field": "Field 1",
+    "calendar_day": "2025-07-22",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1025,
+    "field": "Field 2",
+    "calendar_day": "2025-07-22",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1026,
+    "field": "Field 2",
+    "calendar_day": "2025-07-22",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1027,
+    "field": "Field 2",
+    "calendar_day": "2025-07-22",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1028,
+    "field": "Field 2",
+    "calendar_day": "2025-07-22",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1029,
+    "field": "Field 3",
+    "calendar_day": "2025-07-22",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1030,
+    "field": "Field 3",
+    "calendar_day": "2025-07-22",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1031,
+    "field": "Field 3",
+    "calendar_day": "2025-07-22",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1032,
+    "field": "Field 3",
+    "calendar_day": "2025-07-22",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1033,
+    "field": "Field 1",
+    "calendar_day": "2025-07-23",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1034,
+    "field": "Field 1",
+    "calendar_day": "2025-07-23",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1035,
+    "field": "Field 1",
+    "calendar_day": "2025-07-23",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1036,
+    "field": "Field 1",
+    "calendar_day": "2025-07-23",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1037,
+    "field": "Field 2",
+    "calendar_day": "2025-07-23",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1038,
+    "field": "Field 2",
+    "calendar_day": "2025-07-23",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1039,
+    "field": "Field 2",
+    "calendar_day": "2025-07-23",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1040,
+    "field": "Field 2",
+    "calendar_day": "2025-07-23",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1041,
+    "field": "Field 3",
+    "calendar_day": "2025-07-23",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1042,
+    "field": "Field 3",
+    "calendar_day": "2025-07-23",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1043,
+    "field": "Field 3",
+    "calendar_day": "2025-07-23",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1044,
+    "field": "Field 3",
+    "calendar_day": "2025-07-23",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1045,
+    "field": "Field 1",
+    "calendar_day": "2025-07-24",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1046,
+    "field": "Field 1",
+    "calendar_day": "2025-07-24",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1047,
+    "field": "Field 1",
+    "calendar_day": "2025-07-24",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1048,
+    "field": "Field 1",
+    "calendar_day": "2025-07-24",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1049,
+    "field": "Field 2",
+    "calendar_day": "2025-07-24",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1050,
+    "field": "Field 2",
+    "calendar_day": "2025-07-24",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1051,
+    "field": "Field 2",
+    "calendar_day": "2025-07-24",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1052,
+    "field": "Field 2",
+    "calendar_day": "2025-07-24",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1053,
+    "field": "Field 3",
+    "calendar_day": "2025-07-24",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1054,
+    "field": "Field 3",
+    "calendar_day": "2025-07-24",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1055,
+    "field": "Field 3",
+    "calendar_day": "2025-07-24",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1056,
+    "field": "Field 3",
+    "calendar_day": "2025-07-24",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1057,
+    "field": "Field 1",
+    "calendar_day": "2025-07-25",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1058,
+    "field": "Field 1",
+    "calendar_day": "2025-07-25",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1059,
+    "field": "Field 1",
+    "calendar_day": "2025-07-25",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1060,
+    "field": "Field 1",
+    "calendar_day": "2025-07-25",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1061,
+    "field": "Field 2",
+    "calendar_day": "2025-07-25",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1062,
+    "field": "Field 2",
+    "calendar_day": "2025-07-25",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1063,
+    "field": "Field 2",
+    "calendar_day": "2025-07-25",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1064,
+    "field": "Field 2",
+    "calendar_day": "2025-07-25",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1065,
+    "field": "Field 3",
+    "calendar_day": "2025-07-25",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1066,
+    "field": "Field 3",
+    "calendar_day": "2025-07-25",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1067,
+    "field": "Field 3",
+    "calendar_day": "2025-07-25",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1068,
+    "field": "Field 3",
+    "calendar_day": "2025-07-25",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1069,
+    "field": "Field 1",
+    "calendar_day": "2025-07-26",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1070,
+    "field": "Field 1",
+    "calendar_day": "2025-07-26",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1071,
+    "field": "Field 1",
+    "calendar_day": "2025-07-26",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1072,
+    "field": "Field 1",
+    "calendar_day": "2025-07-26",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1073,
+    "field": "Field 2",
+    "calendar_day": "2025-07-26",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1074,
+    "field": "Field 2",
+    "calendar_day": "2025-07-26",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1075,
+    "field": "Field 2",
+    "calendar_day": "2025-07-26",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1076,
+    "field": "Field 2",
+    "calendar_day": "2025-07-26",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1077,
+    "field": "Field 3",
+    "calendar_day": "2025-07-26",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1078,
+    "field": "Field 3",
+    "calendar_day": "2025-07-26",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1079,
+    "field": "Field 3",
+    "calendar_day": "2025-07-26",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1080,
+    "field": "Field 3",
+    "calendar_day": "2025-07-26",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1081,
+    "field": "Field 1",
+    "calendar_day": "2025-07-27",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1082,
+    "field": "Field 1",
+    "calendar_day": "2025-07-27",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1083,
+    "field": "Field 1",
+    "calendar_day": "2025-07-27",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1084,
+    "field": "Field 1",
+    "calendar_day": "2025-07-27",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1085,
+    "field": "Field 2",
+    "calendar_day": "2025-07-27",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1086,
+    "field": "Field 2",
+    "calendar_day": "2025-07-27",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1087,
+    "field": "Field 2",
+    "calendar_day": "2025-07-27",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1088,
+    "field": "Field 2",
+    "calendar_day": "2025-07-27",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1089,
+    "field": "Field 3",
+    "calendar_day": "2025-07-27",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1090,
+    "field": "Field 3",
+    "calendar_day": "2025-07-27",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1091,
+    "field": "Field 3",
+    "calendar_day": "2025-07-27",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1092,
+    "field": "Field 3",
+    "calendar_day": "2025-07-27",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1093,
+    "field": "Field 1",
+    "calendar_day": "2025-07-28",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1094,
+    "field": "Field 1",
+    "calendar_day": "2025-07-28",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1095,
+    "field": "Field 1",
+    "calendar_day": "2025-07-28",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1096,
+    "field": "Field 1",
+    "calendar_day": "2025-07-28",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1097,
+    "field": "Field 2",
+    "calendar_day": "2025-07-28",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1098,
+    "field": "Field 2",
+    "calendar_day": "2025-07-28",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1099,
+    "field": "Field 2",
+    "calendar_day": "2025-07-28",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1100,
+    "field": "Field 2",
+    "calendar_day": "2025-07-28",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1101,
+    "field": "Field 3",
+    "calendar_day": "2025-07-28",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1102,
+    "field": "Field 3",
+    "calendar_day": "2025-07-28",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1103,
+    "field": "Field 3",
+    "calendar_day": "2025-07-28",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1104,
+    "field": "Field 3",
+    "calendar_day": "2025-07-28",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1105,
+    "field": "Field 1",
+    "calendar_day": "2025-07-29",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1106,
+    "field": "Field 1",
+    "calendar_day": "2025-07-29",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1107,
+    "field": "Field 1",
+    "calendar_day": "2025-07-29",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1108,
+    "field": "Field 1",
+    "calendar_day": "2025-07-29",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1109,
+    "field": "Field 2",
+    "calendar_day": "2025-07-29",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1110,
+    "field": "Field 2",
+    "calendar_day": "2025-07-29",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1111,
+    "field": "Field 2",
+    "calendar_day": "2025-07-29",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1112,
+    "field": "Field 2",
+    "calendar_day": "2025-07-29",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1113,
+    "field": "Field 3",
+    "calendar_day": "2025-07-29",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1114,
+    "field": "Field 3",
+    "calendar_day": "2025-07-29",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1115,
+    "field": "Field 3",
+    "calendar_day": "2025-07-29",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1116,
+    "field": "Field 3",
+    "calendar_day": "2025-07-29",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1117,
+    "field": "Field 1",
+    "calendar_day": "2025-07-30",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1118,
+    "field": "Field 1",
+    "calendar_day": "2025-07-30",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1119,
+    "field": "Field 1",
+    "calendar_day": "2025-07-30",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1120,
+    "field": "Field 1",
+    "calendar_day": "2025-07-30",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1121,
+    "field": "Field 2",
+    "calendar_day": "2025-07-30",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1122,
+    "field": "Field 2",
+    "calendar_day": "2025-07-30",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1123,
+    "field": "Field 2",
+    "calendar_day": "2025-07-30",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1124,
+    "field": "Field 2",
+    "calendar_day": "2025-07-30",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1125,
+    "field": "Field 3",
+    "calendar_day": "2025-07-30",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1126,
+    "field": "Field 3",
+    "calendar_day": "2025-07-30",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1127,
+    "field": "Field 3",
+    "calendar_day": "2025-07-30",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1128,
+    "field": "Field 3",
+    "calendar_day": "2025-07-30",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1129,
+    "field": "Field 1",
+    "calendar_day": "2025-07-31",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1130,
+    "field": "Field 1",
+    "calendar_day": "2025-07-31",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1131,
+    "field": "Field 1",
+    "calendar_day": "2025-07-31",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1132,
+    "field": "Field 1",
+    "calendar_day": "2025-07-31",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1133,
+    "field": "Field 2",
+    "calendar_day": "2025-07-31",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1134,
+    "field": "Field 2",
+    "calendar_day": "2025-07-31",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1135,
+    "field": "Field 2",
+    "calendar_day": "2025-07-31",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1136,
+    "field": "Field 2",
+    "calendar_day": "2025-07-31",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1137,
+    "field": "Field 3",
+    "calendar_day": "2025-07-31",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1138,
+    "field": "Field 3",
+    "calendar_day": "2025-07-31",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1139,
+    "field": "Field 3",
+    "calendar_day": "2025-07-31",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1140,
+    "field": "Field 3",
+    "calendar_day": "2025-07-31",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1141,
+    "field": "Field 1",
+    "calendar_day": "2025-08-01",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1142,
+    "field": "Field 1",
+    "calendar_day": "2025-08-01",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1143,
+    "field": "Field 1",
+    "calendar_day": "2025-08-01",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1144,
+    "field": "Field 1",
+    "calendar_day": "2025-08-01",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1145,
+    "field": "Field 2",
+    "calendar_day": "2025-08-01",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1146,
+    "field": "Field 2",
+    "calendar_day": "2025-08-01",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1147,
+    "field": "Field 2",
+    "calendar_day": "2025-08-01",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1148,
+    "field": "Field 2",
+    "calendar_day": "2025-08-01",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1149,
+    "field": "Field 3",
+    "calendar_day": "2025-08-01",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1150,
+    "field": "Field 3",
+    "calendar_day": "2025-08-01",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1151,
+    "field": "Field 3",
+    "calendar_day": "2025-08-01",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1152,
+    "field": "Field 3",
+    "calendar_day": "2025-08-01",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1153,
+    "field": "Field 1",
+    "calendar_day": "2025-08-02",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1154,
+    "field": "Field 1",
+    "calendar_day": "2025-08-02",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1155,
+    "field": "Field 1",
+    "calendar_day": "2025-08-02",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1156,
+    "field": "Field 1",
+    "calendar_day": "2025-08-02",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1157,
+    "field": "Field 2",
+    "calendar_day": "2025-08-02",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1158,
+    "field": "Field 2",
+    "calendar_day": "2025-08-02",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1159,
+    "field": "Field 2",
+    "calendar_day": "2025-08-02",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1160,
+    "field": "Field 2",
+    "calendar_day": "2025-08-02",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1161,
+    "field": "Field 3",
+    "calendar_day": "2025-08-02",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1162,
+    "field": "Field 3",
+    "calendar_day": "2025-08-02",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1163,
+    "field": "Field 3",
+    "calendar_day": "2025-08-02",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1164,
+    "field": "Field 3",
+    "calendar_day": "2025-08-02",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1165,
+    "field": "Field 1",
+    "calendar_day": "2025-08-03",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1166,
+    "field": "Field 1",
+    "calendar_day": "2025-08-03",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1167,
+    "field": "Field 1",
+    "calendar_day": "2025-08-03",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1168,
+    "field": "Field 1",
+    "calendar_day": "2025-08-03",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1169,
+    "field": "Field 2",
+    "calendar_day": "2025-08-03",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1170,
+    "field": "Field 2",
+    "calendar_day": "2025-08-03",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1171,
+    "field": "Field 2",
+    "calendar_day": "2025-08-03",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1172,
+    "field": "Field 2",
+    "calendar_day": "2025-08-03",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1173,
+    "field": "Field 3",
+    "calendar_day": "2025-08-03",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1174,
+    "field": "Field 3",
+    "calendar_day": "2025-08-03",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1175,
+    "field": "Field 3",
+    "calendar_day": "2025-08-03",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1176,
+    "field": "Field 3",
+    "calendar_day": "2025-08-03",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1177,
+    "field": "Field 1",
+    "calendar_day": "2025-08-04",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1178,
+    "field": "Field 1",
+    "calendar_day": "2025-08-04",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1179,
+    "field": "Field 1",
+    "calendar_day": "2025-08-04",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1180,
+    "field": "Field 1",
+    "calendar_day": "2025-08-04",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1181,
+    "field": "Field 2",
+    "calendar_day": "2025-08-04",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1182,
+    "field": "Field 2",
+    "calendar_day": "2025-08-04",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1183,
+    "field": "Field 2",
+    "calendar_day": "2025-08-04",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1184,
+    "field": "Field 2",
+    "calendar_day": "2025-08-04",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1185,
+    "field": "Field 3",
+    "calendar_day": "2025-08-04",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1186,
+    "field": "Field 3",
+    "calendar_day": "2025-08-04",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1187,
+    "field": "Field 3",
+    "calendar_day": "2025-08-04",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1188,
+    "field": "Field 3",
+    "calendar_day": "2025-08-04",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1189,
+    "field": "Field 1",
+    "calendar_day": "2025-08-05",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1190,
+    "field": "Field 1",
+    "calendar_day": "2025-08-05",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1191,
+    "field": "Field 1",
+    "calendar_day": "2025-08-05",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1192,
+    "field": "Field 1",
+    "calendar_day": "2025-08-05",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1193,
+    "field": "Field 2",
+    "calendar_day": "2025-08-05",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1194,
+    "field": "Field 2",
+    "calendar_day": "2025-08-05",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1195,
+    "field": "Field 2",
+    "calendar_day": "2025-08-05",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1196,
+    "field": "Field 2",
+    "calendar_day": "2025-08-05",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1197,
+    "field": "Field 3",
+    "calendar_day": "2025-08-05",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1198,
+    "field": "Field 3",
+    "calendar_day": "2025-08-05",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1199,
+    "field": "Field 3",
+    "calendar_day": "2025-08-05",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1200,
+    "field": "Field 3",
+    "calendar_day": "2025-08-05",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1201,
+    "field": "Field 1",
+    "calendar_day": "2025-08-06",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1202,
+    "field": "Field 1",
+    "calendar_day": "2025-08-06",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1203,
+    "field": "Field 1",
+    "calendar_day": "2025-08-06",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1204,
+    "field": "Field 1",
+    "calendar_day": "2025-08-06",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1205,
+    "field": "Field 2",
+    "calendar_day": "2025-08-06",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1206,
+    "field": "Field 2",
+    "calendar_day": "2025-08-06",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1207,
+    "field": "Field 2",
+    "calendar_day": "2025-08-06",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1208,
+    "field": "Field 2",
+    "calendar_day": "2025-08-06",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1209,
+    "field": "Field 3",
+    "calendar_day": "2025-08-06",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1210,
+    "field": "Field 3",
+    "calendar_day": "2025-08-06",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1211,
+    "field": "Field 3",
+    "calendar_day": "2025-08-06",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1212,
+    "field": "Field 3",
+    "calendar_day": "2025-08-06",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1213,
+    "field": "Field 1",
+    "calendar_day": "2025-08-07",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1214,
+    "field": "Field 1",
+    "calendar_day": "2025-08-07",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1215,
+    "field": "Field 1",
+    "calendar_day": "2025-08-07",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1216,
+    "field": "Field 1",
+    "calendar_day": "2025-08-07",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1217,
+    "field": "Field 2",
+    "calendar_day": "2025-08-07",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1218,
+    "field": "Field 2",
+    "calendar_day": "2025-08-07",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1219,
+    "field": "Field 2",
+    "calendar_day": "2025-08-07",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1220,
+    "field": "Field 2",
+    "calendar_day": "2025-08-07",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1221,
+    "field": "Field 3",
+    "calendar_day": "2025-08-07",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1222,
+    "field": "Field 3",
+    "calendar_day": "2025-08-07",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1223,
+    "field": "Field 3",
+    "calendar_day": "2025-08-07",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1224,
+    "field": "Field 3",
+    "calendar_day": "2025-08-07",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1225,
+    "field": "Field 1",
+    "calendar_day": "2025-08-08",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1226,
+    "field": "Field 1",
+    "calendar_day": "2025-08-08",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1227,
+    "field": "Field 1",
+    "calendar_day": "2025-08-08",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1228,
+    "field": "Field 1",
+    "calendar_day": "2025-08-08",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1229,
+    "field": "Field 2",
+    "calendar_day": "2025-08-08",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1230,
+    "field": "Field 2",
+    "calendar_day": "2025-08-08",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1231,
+    "field": "Field 2",
+    "calendar_day": "2025-08-08",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1232,
+    "field": "Field 2",
+    "calendar_day": "2025-08-08",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1233,
+    "field": "Field 3",
+    "calendar_day": "2025-08-08",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1234,
+    "field": "Field 3",
+    "calendar_day": "2025-08-08",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1235,
+    "field": "Field 3",
+    "calendar_day": "2025-08-08",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1236,
+    "field": "Field 3",
+    "calendar_day": "2025-08-08",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1237,
+    "field": "Field 1",
+    "calendar_day": "2025-08-09",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1238,
+    "field": "Field 1",
+    "calendar_day": "2025-08-09",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1239,
+    "field": "Field 1",
+    "calendar_day": "2025-08-09",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1240,
+    "field": "Field 1",
+    "calendar_day": "2025-08-09",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1241,
+    "field": "Field 2",
+    "calendar_day": "2025-08-09",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1242,
+    "field": "Field 2",
+    "calendar_day": "2025-08-09",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1243,
+    "field": "Field 2",
+    "calendar_day": "2025-08-09",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1244,
+    "field": "Field 2",
+    "calendar_day": "2025-08-09",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1245,
+    "field": "Field 3",
+    "calendar_day": "2025-08-09",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1246,
+    "field": "Field 3",
+    "calendar_day": "2025-08-09",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1247,
+    "field": "Field 3",
+    "calendar_day": "2025-08-09",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1248,
+    "field": "Field 3",
+    "calendar_day": "2025-08-09",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1249,
+    "field": "Field 1",
+    "calendar_day": "2025-08-10",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1250,
+    "field": "Field 1",
+    "calendar_day": "2025-08-10",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1251,
+    "field": "Field 1",
+    "calendar_day": "2025-08-10",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1252,
+    "field": "Field 1",
+    "calendar_day": "2025-08-10",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1253,
+    "field": "Field 2",
+    "calendar_day": "2025-08-10",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1254,
+    "field": "Field 2",
+    "calendar_day": "2025-08-10",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1255,
+    "field": "Field 2",
+    "calendar_day": "2025-08-10",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1256,
+    "field": "Field 2",
+    "calendar_day": "2025-08-10",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1257,
+    "field": "Field 3",
+    "calendar_day": "2025-08-10",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1258,
+    "field": "Field 3",
+    "calendar_day": "2025-08-10",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1259,
+    "field": "Field 3",
+    "calendar_day": "2025-08-10",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1260,
+    "field": "Field 3",
+    "calendar_day": "2025-08-10",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1261,
+    "field": "Field 1",
+    "calendar_day": "2025-08-11",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1262,
+    "field": "Field 1",
+    "calendar_day": "2025-08-11",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1263,
+    "field": "Field 1",
+    "calendar_day": "2025-08-11",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1264,
+    "field": "Field 1",
+    "calendar_day": "2025-08-11",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1265,
+    "field": "Field 2",
+    "calendar_day": "2025-08-11",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1266,
+    "field": "Field 2",
+    "calendar_day": "2025-08-11",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1267,
+    "field": "Field 2",
+    "calendar_day": "2025-08-11",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1268,
+    "field": "Field 2",
+    "calendar_day": "2025-08-11",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1269,
+    "field": "Field 3",
+    "calendar_day": "2025-08-11",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1270,
+    "field": "Field 3",
+    "calendar_day": "2025-08-11",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1271,
+    "field": "Field 3",
+    "calendar_day": "2025-08-11",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1272,
+    "field": "Field 3",
+    "calendar_day": "2025-08-11",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1273,
+    "field": "Field 1",
+    "calendar_day": "2025-08-12",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1274,
+    "field": "Field 1",
+    "calendar_day": "2025-08-12",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1275,
+    "field": "Field 1",
+    "calendar_day": "2025-08-12",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1276,
+    "field": "Field 1",
+    "calendar_day": "2025-08-12",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1277,
+    "field": "Field 2",
+    "calendar_day": "2025-08-12",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1278,
+    "field": "Field 2",
+    "calendar_day": "2025-08-12",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1279,
+    "field": "Field 2",
+    "calendar_day": "2025-08-12",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1280,
+    "field": "Field 2",
+    "calendar_day": "2025-08-12",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1281,
+    "field": "Field 3",
+    "calendar_day": "2025-08-12",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1282,
+    "field": "Field 3",
+    "calendar_day": "2025-08-12",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1283,
+    "field": "Field 3",
+    "calendar_day": "2025-08-12",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1284,
+    "field": "Field 3",
+    "calendar_day": "2025-08-12",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1285,
+    "field": "Field 1",
+    "calendar_day": "2025-08-13",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1286,
+    "field": "Field 1",
+    "calendar_day": "2025-08-13",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1287,
+    "field": "Field 1",
+    "calendar_day": "2025-08-13",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1288,
+    "field": "Field 1",
+    "calendar_day": "2025-08-13",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1289,
+    "field": "Field 2",
+    "calendar_day": "2025-08-13",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1290,
+    "field": "Field 2",
+    "calendar_day": "2025-08-13",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1291,
+    "field": "Field 2",
+    "calendar_day": "2025-08-13",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1292,
+    "field": "Field 2",
+    "calendar_day": "2025-08-13",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1293,
+    "field": "Field 3",
+    "calendar_day": "2025-08-13",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1294,
+    "field": "Field 3",
+    "calendar_day": "2025-08-13",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1295,
+    "field": "Field 3",
+    "calendar_day": "2025-08-13",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1296,
+    "field": "Field 3",
+    "calendar_day": "2025-08-13",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1297,
+    "field": "Field 1",
+    "calendar_day": "2025-08-14",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1298,
+    "field": "Field 1",
+    "calendar_day": "2025-08-14",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1299,
+    "field": "Field 1",
+    "calendar_day": "2025-08-14",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1300,
+    "field": "Field 1",
+    "calendar_day": "2025-08-14",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1301,
+    "field": "Field 2",
+    "calendar_day": "2025-08-14",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1302,
+    "field": "Field 2",
+    "calendar_day": "2025-08-14",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1303,
+    "field": "Field 2",
+    "calendar_day": "2025-08-14",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1304,
+    "field": "Field 2",
+    "calendar_day": "2025-08-14",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1305,
+    "field": "Field 3",
+    "calendar_day": "2025-08-14",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1306,
+    "field": "Field 3",
+    "calendar_day": "2025-08-14",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1307,
+    "field": "Field 3",
+    "calendar_day": "2025-08-14",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1308,
+    "field": "Field 3",
+    "calendar_day": "2025-08-14",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1309,
+    "field": "Field 1",
+    "calendar_day": "2025-08-15",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1310,
+    "field": "Field 1",
+    "calendar_day": "2025-08-15",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1311,
+    "field": "Field 1",
+    "calendar_day": "2025-08-15",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1312,
+    "field": "Field 1",
+    "calendar_day": "2025-08-15",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1313,
+    "field": "Field 2",
+    "calendar_day": "2025-08-15",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1314,
+    "field": "Field 2",
+    "calendar_day": "2025-08-15",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1315,
+    "field": "Field 2",
+    "calendar_day": "2025-08-15",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1316,
+    "field": "Field 2",
+    "calendar_day": "2025-08-15",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1317,
+    "field": "Field 3",
+    "calendar_day": "2025-08-15",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1318,
+    "field": "Field 3",
+    "calendar_day": "2025-08-15",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1319,
+    "field": "Field 3",
+    "calendar_day": "2025-08-15",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1320,
+    "field": "Field 3",
+    "calendar_day": "2025-08-15",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1321,
+    "field": "Field 1",
+    "calendar_day": "2025-08-16",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1322,
+    "field": "Field 1",
+    "calendar_day": "2025-08-16",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1323,
+    "field": "Field 1",
+    "calendar_day": "2025-08-16",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1324,
+    "field": "Field 1",
+    "calendar_day": "2025-08-16",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1325,
+    "field": "Field 2",
+    "calendar_day": "2025-08-16",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1326,
+    "field": "Field 2",
+    "calendar_day": "2025-08-16",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1327,
+    "field": "Field 2",
+    "calendar_day": "2025-08-16",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1328,
+    "field": "Field 2",
+    "calendar_day": "2025-08-16",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1329,
+    "field": "Field 3",
+    "calendar_day": "2025-08-16",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1330,
+    "field": "Field 3",
+    "calendar_day": "2025-08-16",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1331,
+    "field": "Field 3",
+    "calendar_day": "2025-08-16",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1332,
+    "field": "Field 3",
+    "calendar_day": "2025-08-16",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1333,
+    "field": "Field 1",
+    "calendar_day": "2025-08-17",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1334,
+    "field": "Field 1",
+    "calendar_day": "2025-08-17",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1335,
+    "field": "Field 1",
+    "calendar_day": "2025-08-17",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1336,
+    "field": "Field 1",
+    "calendar_day": "2025-08-17",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1337,
+    "field": "Field 2",
+    "calendar_day": "2025-08-17",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1338,
+    "field": "Field 2",
+    "calendar_day": "2025-08-17",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1339,
+    "field": "Field 2",
+    "calendar_day": "2025-08-17",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1340,
+    "field": "Field 2",
+    "calendar_day": "2025-08-17",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1341,
+    "field": "Field 3",
+    "calendar_day": "2025-08-17",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1342,
+    "field": "Field 3",
+    "calendar_day": "2025-08-17",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1343,
+    "field": "Field 3",
+    "calendar_day": "2025-08-17",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1344,
+    "field": "Field 3",
+    "calendar_day": "2025-08-17",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1345,
+    "field": "Field 1",
+    "calendar_day": "2025-08-18",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1346,
+    "field": "Field 1",
+    "calendar_day": "2025-08-18",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1347,
+    "field": "Field 1",
+    "calendar_day": "2025-08-18",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1348,
+    "field": "Field 1",
+    "calendar_day": "2025-08-18",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1349,
+    "field": "Field 2",
+    "calendar_day": "2025-08-18",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1350,
+    "field": "Field 2",
+    "calendar_day": "2025-08-18",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1351,
+    "field": "Field 2",
+    "calendar_day": "2025-08-18",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1352,
+    "field": "Field 2",
+    "calendar_day": "2025-08-18",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1353,
+    "field": "Field 3",
+    "calendar_day": "2025-08-18",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1354,
+    "field": "Field 3",
+    "calendar_day": "2025-08-18",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1355,
+    "field": "Field 3",
+    "calendar_day": "2025-08-18",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1356,
+    "field": "Field 3",
+    "calendar_day": "2025-08-18",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1357,
+    "field": "Field 1",
+    "calendar_day": "2025-08-19",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1358,
+    "field": "Field 1",
+    "calendar_day": "2025-08-19",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1359,
+    "field": "Field 1",
+    "calendar_day": "2025-08-19",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1360,
+    "field": "Field 1",
+    "calendar_day": "2025-08-19",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1361,
+    "field": "Field 2",
+    "calendar_day": "2025-08-19",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1362,
+    "field": "Field 2",
+    "calendar_day": "2025-08-19",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1363,
+    "field": "Field 2",
+    "calendar_day": "2025-08-19",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1364,
+    "field": "Field 2",
+    "calendar_day": "2025-08-19",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1365,
+    "field": "Field 3",
+    "calendar_day": "2025-08-19",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1366,
+    "field": "Field 3",
+    "calendar_day": "2025-08-19",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1367,
+    "field": "Field 3",
+    "calendar_day": "2025-08-19",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1368,
+    "field": "Field 3",
+    "calendar_day": "2025-08-19",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1369,
+    "field": "Field 1",
+    "calendar_day": "2025-08-20",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1370,
+    "field": "Field 1",
+    "calendar_day": "2025-08-20",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1371,
+    "field": "Field 1",
+    "calendar_day": "2025-08-20",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1372,
+    "field": "Field 1",
+    "calendar_day": "2025-08-20",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1373,
+    "field": "Field 2",
+    "calendar_day": "2025-08-20",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1374,
+    "field": "Field 2",
+    "calendar_day": "2025-08-20",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1375,
+    "field": "Field 2",
+    "calendar_day": "2025-08-20",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1376,
+    "field": "Field 2",
+    "calendar_day": "2025-08-20",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1377,
+    "field": "Field 3",
+    "calendar_day": "2025-08-20",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1378,
+    "field": "Field 3",
+    "calendar_day": "2025-08-20",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1379,
+    "field": "Field 3",
+    "calendar_day": "2025-08-20",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1380,
+    "field": "Field 3",
+    "calendar_day": "2025-08-20",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1381,
+    "field": "Field 1",
+    "calendar_day": "2025-08-21",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1382,
+    "field": "Field 1",
+    "calendar_day": "2025-08-21",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1383,
+    "field": "Field 1",
+    "calendar_day": "2025-08-21",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1384,
+    "field": "Field 1",
+    "calendar_day": "2025-08-21",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1385,
+    "field": "Field 2",
+    "calendar_day": "2025-08-21",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1386,
+    "field": "Field 2",
+    "calendar_day": "2025-08-21",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1387,
+    "field": "Field 2",
+    "calendar_day": "2025-08-21",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1388,
+    "field": "Field 2",
+    "calendar_day": "2025-08-21",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1389,
+    "field": "Field 3",
+    "calendar_day": "2025-08-21",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1390,
+    "field": "Field 3",
+    "calendar_day": "2025-08-21",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1391,
+    "field": "Field 3",
+    "calendar_day": "2025-08-21",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1392,
+    "field": "Field 3",
+    "calendar_day": "2025-08-21",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1393,
+    "field": "Field 1",
+    "calendar_day": "2025-08-22",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1394,
+    "field": "Field 1",
+    "calendar_day": "2025-08-22",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1395,
+    "field": "Field 1",
+    "calendar_day": "2025-08-22",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1396,
+    "field": "Field 1",
+    "calendar_day": "2025-08-22",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1397,
+    "field": "Field 2",
+    "calendar_day": "2025-08-22",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1398,
+    "field": "Field 2",
+    "calendar_day": "2025-08-22",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1399,
+    "field": "Field 2",
+    "calendar_day": "2025-08-22",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1400,
+    "field": "Field 2",
+    "calendar_day": "2025-08-22",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1401,
+    "field": "Field 3",
+    "calendar_day": "2025-08-22",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1402,
+    "field": "Field 3",
+    "calendar_day": "2025-08-22",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1403,
+    "field": "Field 3",
+    "calendar_day": "2025-08-22",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1404,
+    "field": "Field 3",
+    "calendar_day": "2025-08-22",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1405,
+    "field": "Field 1",
+    "calendar_day": "2025-08-23",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1406,
+    "field": "Field 1",
+    "calendar_day": "2025-08-23",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1407,
+    "field": "Field 1",
+    "calendar_day": "2025-08-23",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1408,
+    "field": "Field 1",
+    "calendar_day": "2025-08-23",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1409,
+    "field": "Field 2",
+    "calendar_day": "2025-08-23",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1410,
+    "field": "Field 2",
+    "calendar_day": "2025-08-23",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1411,
+    "field": "Field 2",
+    "calendar_day": "2025-08-23",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1412,
+    "field": "Field 2",
+    "calendar_day": "2025-08-23",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1413,
+    "field": "Field 3",
+    "calendar_day": "2025-08-23",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1414,
+    "field": "Field 3",
+    "calendar_day": "2025-08-23",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1415,
+    "field": "Field 3",
+    "calendar_day": "2025-08-23",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1416,
+    "field": "Field 3",
+    "calendar_day": "2025-08-23",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1417,
+    "field": "Field 1",
+    "calendar_day": "2025-08-24",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1418,
+    "field": "Field 1",
+    "calendar_day": "2025-08-24",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1419,
+    "field": "Field 1",
+    "calendar_day": "2025-08-24",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1420,
+    "field": "Field 1",
+    "calendar_day": "2025-08-24",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1421,
+    "field": "Field 2",
+    "calendar_day": "2025-08-24",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1422,
+    "field": "Field 2",
+    "calendar_day": "2025-08-24",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1423,
+    "field": "Field 2",
+    "calendar_day": "2025-08-24",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1424,
+    "field": "Field 2",
+    "calendar_day": "2025-08-24",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1425,
+    "field": "Field 3",
+    "calendar_day": "2025-08-24",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1426,
+    "field": "Field 3",
+    "calendar_day": "2025-08-24",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1427,
+    "field": "Field 3",
+    "calendar_day": "2025-08-24",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1428,
+    "field": "Field 3",
+    "calendar_day": "2025-08-24",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1429,
+    "field": "Field 1",
+    "calendar_day": "2025-08-25",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1430,
+    "field": "Field 1",
+    "calendar_day": "2025-08-25",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1431,
+    "field": "Field 1",
+    "calendar_day": "2025-08-25",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1432,
+    "field": "Field 1",
+    "calendar_day": "2025-08-25",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1433,
+    "field": "Field 2",
+    "calendar_day": "2025-08-25",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1434,
+    "field": "Field 2",
+    "calendar_day": "2025-08-25",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1435,
+    "field": "Field 2",
+    "calendar_day": "2025-08-25",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1436,
+    "field": "Field 2",
+    "calendar_day": "2025-08-25",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1437,
+    "field": "Field 3",
+    "calendar_day": "2025-08-25",
+    "day_of_week": "Monday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1438,
+    "field": "Field 3",
+    "calendar_day": "2025-08-25",
+    "day_of_week": "Monday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1439,
+    "field": "Field 3",
+    "calendar_day": "2025-08-25",
+    "day_of_week": "Monday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1440,
+    "field": "Field 3",
+    "calendar_day": "2025-08-25",
+    "day_of_week": "Monday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1441,
+    "field": "Field 1",
+    "calendar_day": "2025-08-26",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1442,
+    "field": "Field 1",
+    "calendar_day": "2025-08-26",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1443,
+    "field": "Field 1",
+    "calendar_day": "2025-08-26",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1444,
+    "field": "Field 1",
+    "calendar_day": "2025-08-26",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1445,
+    "field": "Field 2",
+    "calendar_day": "2025-08-26",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1446,
+    "field": "Field 2",
+    "calendar_day": "2025-08-26",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1447,
+    "field": "Field 2",
+    "calendar_day": "2025-08-26",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1448,
+    "field": "Field 2",
+    "calendar_day": "2025-08-26",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1449,
+    "field": "Field 3",
+    "calendar_day": "2025-08-26",
+    "day_of_week": "Tuesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1450,
+    "field": "Field 3",
+    "calendar_day": "2025-08-26",
+    "day_of_week": "Tuesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1451,
+    "field": "Field 3",
+    "calendar_day": "2025-08-26",
+    "day_of_week": "Tuesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1452,
+    "field": "Field 3",
+    "calendar_day": "2025-08-26",
+    "day_of_week": "Tuesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1453,
+    "field": "Field 1",
+    "calendar_day": "2025-08-27",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1454,
+    "field": "Field 1",
+    "calendar_day": "2025-08-27",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1455,
+    "field": "Field 1",
+    "calendar_day": "2025-08-27",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1456,
+    "field": "Field 1",
+    "calendar_day": "2025-08-27",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1457,
+    "field": "Field 2",
+    "calendar_day": "2025-08-27",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1458,
+    "field": "Field 2",
+    "calendar_day": "2025-08-27",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1459,
+    "field": "Field 2",
+    "calendar_day": "2025-08-27",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1460,
+    "field": "Field 2",
+    "calendar_day": "2025-08-27",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1461,
+    "field": "Field 3",
+    "calendar_day": "2025-08-27",
+    "day_of_week": "Wednesday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1462,
+    "field": "Field 3",
+    "calendar_day": "2025-08-27",
+    "day_of_week": "Wednesday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1463,
+    "field": "Field 3",
+    "calendar_day": "2025-08-27",
+    "day_of_week": "Wednesday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1464,
+    "field": "Field 3",
+    "calendar_day": "2025-08-27",
+    "day_of_week": "Wednesday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1465,
+    "field": "Field 1",
+    "calendar_day": "2025-08-28",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1466,
+    "field": "Field 1",
+    "calendar_day": "2025-08-28",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1467,
+    "field": "Field 1",
+    "calendar_day": "2025-08-28",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1468,
+    "field": "Field 1",
+    "calendar_day": "2025-08-28",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1469,
+    "field": "Field 2",
+    "calendar_day": "2025-08-28",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1470,
+    "field": "Field 2",
+    "calendar_day": "2025-08-28",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1471,
+    "field": "Field 2",
+    "calendar_day": "2025-08-28",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1472,
+    "field": "Field 2",
+    "calendar_day": "2025-08-28",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1473,
+    "field": "Field 3",
+    "calendar_day": "2025-08-28",
+    "day_of_week": "Thursday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1474,
+    "field": "Field 3",
+    "calendar_day": "2025-08-28",
+    "day_of_week": "Thursday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1475,
+    "field": "Field 3",
+    "calendar_day": "2025-08-28",
+    "day_of_week": "Thursday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1476,
+    "field": "Field 3",
+    "calendar_day": "2025-08-28",
+    "day_of_week": "Thursday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1477,
+    "field": "Field 1",
+    "calendar_day": "2025-08-29",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1478,
+    "field": "Field 1",
+    "calendar_day": "2025-08-29",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1479,
+    "field": "Field 1",
+    "calendar_day": "2025-08-29",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1480,
+    "field": "Field 1",
+    "calendar_day": "2025-08-29",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1481,
+    "field": "Field 2",
+    "calendar_day": "2025-08-29",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1482,
+    "field": "Field 2",
+    "calendar_day": "2025-08-29",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1483,
+    "field": "Field 2",
+    "calendar_day": "2025-08-29",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1484,
+    "field": "Field 2",
+    "calendar_day": "2025-08-29",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1485,
+    "field": "Field 3",
+    "calendar_day": "2025-08-29",
+    "day_of_week": "Friday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1486,
+    "field": "Field 3",
+    "calendar_day": "2025-08-29",
+    "day_of_week": "Friday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1487,
+    "field": "Field 3",
+    "calendar_day": "2025-08-29",
+    "day_of_week": "Friday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1488,
+    "field": "Field 3",
+    "calendar_day": "2025-08-29",
+    "day_of_week": "Friday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1489,
+    "field": "Field 1",
+    "calendar_day": "2025-08-30",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1490,
+    "field": "Field 1",
+    "calendar_day": "2025-08-30",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1491,
+    "field": "Field 1",
+    "calendar_day": "2025-08-30",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1492,
+    "field": "Field 1",
+    "calendar_day": "2025-08-30",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1493,
+    "field": "Field 2",
+    "calendar_day": "2025-08-30",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1494,
+    "field": "Field 2",
+    "calendar_day": "2025-08-30",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1495,
+    "field": "Field 2",
+    "calendar_day": "2025-08-30",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1496,
+    "field": "Field 2",
+    "calendar_day": "2025-08-30",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1497,
+    "field": "Field 3",
+    "calendar_day": "2025-08-30",
+    "day_of_week": "Saturday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1498,
+    "field": "Field 3",
+    "calendar_day": "2025-08-30",
+    "day_of_week": "Saturday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1499,
+    "field": "Field 3",
+    "calendar_day": "2025-08-30",
+    "day_of_week": "Saturday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1500,
+    "field": "Field 3",
+    "calendar_day": "2025-08-30",
+    "day_of_week": "Saturday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1501,
+    "field": "Field 1",
+    "calendar_day": "2025-08-31",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1502,
+    "field": "Field 1",
+    "calendar_day": "2025-08-31",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1503,
+    "field": "Field 1",
+    "calendar_day": "2025-08-31",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1504,
+    "field": "Field 1",
+    "calendar_day": "2025-08-31",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1505,
+    "field": "Field 2",
+    "calendar_day": "2025-08-31",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1506,
+    "field": "Field 2",
+    "calendar_day": "2025-08-31",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1507,
+    "field": "Field 2",
+    "calendar_day": "2025-08-31",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1508,
+    "field": "Field 2",
+    "calendar_day": "2025-08-31",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  },
+  {
+    "slot_id": 1509,
+    "field": "Field 3",
+    "calendar_day": "2025-08-31",
+    "day_of_week": "Sunday",
+    "time": "5:00"
+  },
+  {
+    "slot_id": 1510,
+    "field": "Field 3",
+    "calendar_day": "2025-08-31",
+    "day_of_week": "Sunday",
+    "time": "6:30"
+  },
+  {
+    "slot_id": 1511,
+    "field": "Field 3",
+    "calendar_day": "2025-08-31",
+    "day_of_week": "Sunday",
+    "time": "8:00"
+  },
+  {
+    "slot_id": 1512,
+    "field": "Field 3",
+    "calendar_day": "2025-08-31",
+    "day_of_week": "Sunday",
+    "time": "9:30"
+  }
+]

--- a/docs/Presentations/D0_ProofOfConceptDemo/data/teams.json
+++ b/docs/Presentations/D0_ProofOfConceptDemo/data/teams.json
@@ -1,0 +1,212 @@
+[
+  {
+    "id": 1,
+    "name": "Thunderbolts",
+    "division": "A",
+    "blacklist_days": [],
+    "preferred_times": ["6:30", "8:00"]
+  },
+  {
+    "id": 2,
+    "name": "Red Rockets",
+    "division": "A",
+    "blacklist_days": [],
+    "preferred_times": ["5:00", "8:00"]
+  },
+  {
+    "id": 3,
+    "name": "Blue Blazers",
+    "division": "A",
+    "blacklist_days": [],
+    "preferred_times": []
+  },
+  {
+    "id": 4,
+    "name": "Golden Griffins",
+    "division": "A",
+    "blacklist_days": [],
+    "preferred_times": ["5:00", "9:30"]
+  },
+  {
+    "id": 5,
+    "name": "Emerald Eagles",
+    "division": "A",
+    "blacklist_days": [],
+    "preferred_times": ["6:30"]
+  },
+  {
+    "id": 6,
+    "name": "Silver Sharks",
+    "division": "B",
+    "blacklist_days": [],
+    "preferred_times": ["8:00", "9:30"]
+  },
+  {
+    "id": 7,
+    "name": "Crimson Coyotes",
+    "division": "B",
+    "blacklist_days": [],
+    "preferred_times": ["6:30", "8:00"]
+  },
+  {
+    "id": 8,
+    "name": "Ivory Irons",
+    "division": "B",
+    "blacklist_days": [],
+    "preferred_times": ["5:00", "6:30"]
+  },
+  {
+    "id": 9,
+    "name": "Amber Arrows",
+    "division": "B",
+    "blacklist_days": [],
+    "preferred_times": []
+  },
+  {
+    "id": 10,
+    "name": "Bronze Bears",
+    "division": "B",
+    "blacklist_days": [],
+    "preferred_times": ["6:30", "8:00"]
+  },
+  {
+    "id": 11,
+    "name": "Onyx Owls",
+    "division": "B",
+    "blacklist_days": ["Monday"],
+    "preferred_times": ["9:30"]
+  },
+  {
+    "id": 12,
+    "name": "Azure Aces",
+    "division": "C",
+    "blacklist_days": ["Wednesday"],
+    "preferred_times": ["6:30", "9:30"]
+  },
+  {
+    "id": 13,
+    "name": "Obsidian Ocelots",
+    "division": "C",
+    "blacklist_days": ["Friday"],
+    "preferred_times": ["5:00", "8:00"]
+  },
+  {
+    "id": 14,
+    "name": "Pearl Pythons",
+    "division": "C",
+    "blacklist_days": ["Tuesday"],
+    "preferred_times": ["8:00", "9:30"]
+  },
+  {
+    "id": 15,
+    "name": "Scarlet Scorpions",
+    "division": "C",
+    "blacklist_days": ["Monday"],
+    "preferred_times": ["5:00", "6:30"]
+  },
+  {
+    "id": 16,
+    "name": "Ivory Eagles",
+    "division": "C",
+    "blacklist_days": ["Thursday"],
+    "preferred_times": ["6:30", "9:30"]
+  },
+  {
+    "id": 17,
+    "name": "Copper Cobras",
+    "division": "C",
+    "blacklist_days": ["Wednesday"],
+    "preferred_times": []
+  },
+  {
+    "id": 18,
+    "name": "Ruby Raptors",
+    "division": "D",
+    "blacklist_days": ["Friday"],
+    "preferred_times": ["5:00", "8:00"]
+  },
+  {
+    "id": 19,
+    "name": "Topaz Tigers",
+    "division": "D",
+    "blacklist_days": ["Tuesday"],
+    "preferred_times": ["8:00"]
+  },
+  {
+    "id": 20,
+    "name": "Lapis Lions",
+    "division": "D",
+    "blacklist_days": ["Thursday"],
+    "preferred_times": ["5:00", "6:30"]
+  },
+  {
+    "id": 21,
+    "name": "Jade Jaguars",
+    "division": "D",
+    "blacklist_days": ["Monday"],
+    "preferred_times": ["6:30"]
+  },
+  {
+    "id": 22,
+    "name": "Cobalt Cougars",
+    "division": "D",
+    "blacklist_days": ["Wednesday"],
+    "preferred_times": ["5:00", "6:30"]
+  },
+  {
+    "id": 23,
+    "name": "Quartz Quails",
+    "division": "D",
+    "blacklist_days": ["Friday"],
+    "preferred_times": ["6:30", "8:00"]
+  },
+  {
+    "id": 24,
+    "name": "Crystal Cardinals",
+    "division": "D",
+    "blacklist_days": ["Tuesday"],
+    "preferred_times": ["9:30"]
+  },
+  {
+    "id": 25,
+    "name": "Zinc Zebras",
+    "division": "D",
+    "blacklist_days": ["Thursday"],
+    "preferred_times": ["8:00", "9:30"]
+  },
+  {
+    "id": 26,
+    "name": "Titanium Toucans",
+    "division": "A",
+    "blacklist_days": ["Monday"],
+    "preferred_times": ["5:00", "6:30"]
+  },
+  {
+    "id": 27,
+    "name": "Iron Ibis",
+    "division": "A",
+    "blacklist_days": ["Wednesday"],
+    "preferred_times": ["8:00"]
+  },
+  {
+    "id": 28,
+    "name": "Magenta Monkeys",
+    "division": "A",
+    "blacklist_days": ["Monday", "Friday"],
+    "preferred_times": []
+  },
+  {
+    "id": 29,
+    "name": "Garnet Gazelles",
+    "division": "B",
+    "blacklist_days": ["Monday", "Tuesday"],
+    "preferred_times": ["8:00", "9:30"]
+  },
+  {
+    "id": 30,
+    "name": "Sapphire Swans",
+    "division": "C",
+    "blacklist_days": ["Thursday", "Friday"],
+    "preferred_times": ["5:00", "8:00"]
+  }
+]


### PR DESCRIPTION
# Adding test data for POC
Adding dummy team and gameslot .json files to be used for POC demonstrations. These will be used by a scheduling algorithm to generate a schedule output for the season.

Please review and make sure that the fields are sufficient to create a POC scheduling algorithm @emmawigglesworth @JadHay8 @temituoyo 

## Team Data:
**Structure**:
``` 
Example
  {
    "id": 1, 
    "name": "Thunderbolts",
    "division": "A", 
    "blacklist_days": ["Monday"], // choose days to avoid in schedule
    "preferred_times": ["6:30", "8:00"] // choose preferred game times in schedule
  }
```
### `teams.json` metadata
**Teams**: 30
**id**: unique identifier
**name**: captain-chosen team name
**division**: skill division A, B, C, D ( this dataset has `Count: A: 8, B: 7, C: 7, D: 8`)
**blacklist_days**: can be any day of the week, captain chooses days to avoid (if possible) in schedule
**preferred_times**: can be any in `[5:00, 6:30, 8:00, 9:30]`, captain chooses preferred game times (if possible) in schedule

In the future (or if needed for this POC) we can add/clarify the blacklist days, times, more metadata, etc.

## Game slots
``` 
Example
  {
    "slot_id": 1, 
    "field": "Field 1", 
    "calendar_day": "2025-04-28",
    "day_of_week": "Monday",
    "time": "5:00"
  }
```
### `slots.json` metadata
**slots**: 1512 (3 fields * 4 time slots * 126 days in season)
**slot_id**: unique identifier representing a game slot (date+time+location)
**field**: location of game, can be Field 1, 2, 3
**calendar_day**: day of the year. Similar to existing schedule, data includes season games from Apr 28 2025 (Mon) - Sep 1 2025 (Mon)
**day_of_week**: can be any day of the week,
**time**: Game time, can be any in `[5:00, 6:30, 8:00, 9:30]`

Closes #109 