### PR TITLE
MG - Traceability table for Anticipated Changes

### DIFF
--- a/docs/Design/SoftArchitecture/MG.tex
+++ b/docs/Design/SoftArchitecture/MG.tex
@@ -526,18 +526,14 @@ R12 & \mref{mUI}, \mref{mGameManagement}, \mref{mBackend}\\
 \toprule
 \textbf{AC} & \textbf{Modules}\\
 \midrule
-\acref{acHardware} & \mref{mHH}\\
-\acref{acInput} & \mref{mInput}\\
-\acref{acParams} & \mref{mParams}\\
-\acref{acVerify} & \mref{mVerify}\\
-\acref{acOutput} & \mref{mOutput}\\
-\acref{acVerifyOut} & \mref{mVerifyOut}\\
-\acref{acODEs} & \mref{mODEs}\\
-\acref{acEnergy} & \mref{mEnergy}\\
-\acref{acControl} & \mref{mControl}\\
-\acref{acSeqDS} & \mref{mSeqDS}\\
-\acref{acSolver} & \mref{mSolver}\\
-\acref{acPlot} & \mref{mPlot}\\
+% \acref{acHardware} & \mref{mHH}\\
+AC1 & \mref{mUI}, \mref{mAuth}, \mref{mBackend}\\
+AC2 & \mref{mUI}, \mref{mAuth}, \mref{mBackend}\\
+AC3 & \mref{mAuth}, \mref{mTeamManagement}, \mref{mStandings}, \mref{mBackend}\\
+AC4 & \mref{mUI}, \mref{mNotification}\\
+AC5 & \mref{mScheduling}, \mref{mAlgo}\\
+AC6 & \mref{mAuth}, \mref{mStandings}, \mref{mBackend}\\
+AC7 & \mref{mNotification}, \mref{mBackend}\\
 \bottomrule
 \end{tabular}
 \caption{Trace Between Anticipated Changes and Modules}


### PR DESCRIPTION
Document the traceability between Anticipated changes and Modules. Further updates for the reference of the anticipated changes after #199 is merged.
Closes #195 