### PR TITLE
Update Reference Point in Traceability Matrix 2

### DIFF
--- a/docs/Design/SoftArchitecture/MG.tex
+++ b/docs/Design/SoftArchitecture/MG.tex
@@ -532,13 +532,13 @@ R12 & \mref{mUI}, \mref{mGameManagement}, \mref{mBackend}\\
 \textbf{AC} & \textbf{Modules}\\
 \midrule
 % \acref{acHardware} & \mref{mHH}\\
-AC1 & \mref{mUI}, \mref{mAuth}, \mref{mBackend}\\
-AC2 & \mref{mUI}, \mref{mAuth}, \mref{mBackend}\\
-AC3 & \mref{mAuth}, \mref{mTeamManagement}, \mref{mStandings}, \mref{mBackend}\\
-AC4 & \mref{mUI}, \mref{mNotification}\\
-AC5 & \mref{mScheduling}, \mref{mAlgo}\\
-AC6 & \mref{mAuth}, \mref{mStandings}, \mref{mBackend}\\
-AC7 & \mref{mNotification}, \mref{mBackend}\\
+\acref{acEnhancedAuth} & \mref{mUI}, \mref{mAuth}, \mref{mBackend}\\
+\acref{acSessionUpdate} & \mref{mUI}, \mref{mAuth}, \mref{mBackend}\\
+\acref{acDbSchema} & \mref{mAuth}, \mref{mTeamManagement}, \mref{mStandings}, \mref{mBackend}\\
+\acref{acUIEnhance} & \mref{mUI}, \mref{mNotification}\\
+\acref{acNewAlg} & \mref{mScheduling}, \mref{mAlgo}\\
+\acref{acDataSecurity} & \mref{mAuth}, \mref{mStandings}, \mref{mBackend}\\
+\acref{acNotifSystem} & \mref{mNotification}, \mref{mBackend}\\
 \bottomrule
 \end{tabular}
 \caption{Trace Between Anticipated Changes and Modules}


### PR DESCRIPTION
Update the Traceability Matrix of Anticipated Changes to use referenced points instead of hard coded values.

![Modules](https://github.com/user-attachments/assets/9409c338-64cd-47b5-9317-be94e85149b8)

Closes #212 