### PR TITLE
Start of Commissioner League management page

### DIFF
--- a/src/frontend/src/components/ScheduleTable.jsx
+++ b/src/frontend/src/components/ScheduleTable.jsx
@@ -7,28 +7,27 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  Typography,
 } from "@mui/material";
 
 export default function ScheduleTable(props) {
   return (
-    <TableContainer component={Paper} sx={{ mb: 6 }}>
-      <Table>
+    <TableContainer component={Paper} sx={{ mb: 6, maxHeight: "50vh" }}>
+      <Table stickyHeader>
         <TableHead>
           <TableRow>
-            <TableCell>Date</TableCell>
-            <TableCell>Opposing Team</TableCell>
-            <TableCell>Result</TableCell>
-            <TableCell>Score</TableCell>
+            {props.columns.map((column, index) => (
+              <TableCell key={index}>{column.header}</TableCell>
+            ))}
           </TableRow>
         </TableHead>
         <TableBody>
-          {props.games.map((game, index) => (
-            <TableRow key={index}>
-              <TableCell>{game.date}</TableCell>
-              <TableCell>{game.team}</TableCell>
-              <TableCell>{game.result}</TableCell>
-              <TableCell>{game.score}</TableCell>
+          {props.data.map((row, rowIndex) => (
+            <TableRow key={rowIndex}>
+              {props.columns.map((column, colIndex) => (
+                <TableCell key={colIndex} sx={{ height: 12 }}>
+                  {column.accessor ? column.accessor(row) : row[column.key]}
+                </TableCell>
+              ))}
             </TableRow>
           ))}
         </TableBody>

--- a/src/frontend/src/components/TeamTable.jsx
+++ b/src/frontend/src/components/TeamTable.jsx
@@ -1,0 +1,92 @@
+import React, { useState } from "react";
+import {
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Select,
+  MenuItem,
+  FormControlLabel,
+  Checkbox,
+} from "@mui/material";
+
+export default function TeamTable(props) {
+  const [teams, setTeams] = useState(props.teams);
+
+  const handleDivisionChange = (name, newDivision) => {
+    console.log(`Changing division for team ${name} to ${newDivision}`);
+
+    setTeams(
+      teams.map((team) =>
+        team.name === name ? { ...team, division: newDivision } : team
+      )
+    );
+  };
+
+  const handlePaymentToggle = (name) => {
+    console.log(`Changing paid for team ${name}`);
+
+    setTeams(
+      teams.map((team) =>
+        team.name === name ? { ...team, paid: !team.paid } : team
+      )
+    );
+  };
+
+  return (
+    <TableContainer component={Paper} sx={{ maxHeight: "40vh", mb: 2 }}>
+      <Table stickyHeader aria-label="team management table" size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Team Name</TableCell>
+            <TableCell>Captain</TableCell>
+            <TableCell>Division</TableCell>
+            <TableCell>Payment Status</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {teams.map((team) => (
+            <TableRow key={team.id}>
+              <TableCell>{team.name}</TableCell>
+              <TableCell>{team.captain}</TableCell>
+              <TableCell>
+                <Select
+                  defaultValue={team.division}
+                  value={team.division}
+                  onChange={(e) =>
+                    handleDivisionChange(team.name, e.target.value)
+                  }
+                  size="small"
+                  sx={{ mt: 0, mb: 0, padding: 0, height: 24 }}
+                >
+                  {props.divisions.map((division) => (
+                    <MenuItem key={division.id} value={division.name}>
+                      {division.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </TableCell>
+              <TableCell>
+                <FormControlLabel
+                  sx={{ mt: 0, mb: 0, padding: 0, height: 20 }}
+                  control={
+                    <Checkbox
+                      checked={team.paid}
+                      onChange={() => handlePaymentToggle(team.name)}
+                      name={`paid-${team.id}`}
+                      size="small"
+                    />
+                  }
+                  label="Paid"
+                />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/src/frontend/src/data/schedule.json
+++ b/src/frontend/src/data/schedule.json
@@ -1,0 +1,82 @@
+[
+    {
+        "game_id": 1,
+        "game_slot": 1,
+        "team1": "Team 1",
+        "team2": "Team 2",
+        "date": "2023-10-01",
+        "field": 1,
+        "time": "5:00 PM",
+        "division": "A"
+    },
+    {
+        "game_id": 2,
+        "game_slot": 2,
+        "team1": "Team 3",
+        "team2": "Team 4",
+        "date": "2023-10-01",
+        "field": 2,
+        "time": "6:30 PM",
+        "division": "B"
+    },
+    {
+        "game_id": 3,
+        "game_slot": 3,
+        "team1": "Team 5",
+        "team2": "Team 6",
+        "date": "2023-10-01",
+        "field": 3,
+        "time": "8:00 PM",
+        "division": "C"
+    },
+    {
+        "game_id": 4,
+        "game_slot": 4,
+        "team1": "Team 7",
+        "team2": "Team 8",
+        "date": "2023-10-01",
+        "field": 1,
+        "time": "9:30 PM",
+        "division": "D"
+    },
+    {
+        "game_id": 5,
+        "game_slot": 5,
+        "team1": "Team 9",
+        "team2": "Team 10",
+        "date": "2023-10-08",
+        "field": 2,
+        "time": "5:00 PM",
+        "division": "A"
+    },
+    {
+        "game_id": 6,
+        "game_slot": 6,
+        "team1": "Team 11",
+        "team2": "Team 12",
+        "date": "2023-10-08",
+        "field": 3,
+        "time": "6:30 PM",
+        "division": "B"
+    },
+    {
+        "game_id": 7,
+        "game_slot": 7,
+        "team1": "Team 13",
+        "team2": "Team 14",
+        "date": "2023-10-08",
+        "field": 1,
+        "time": "8:00 PM",
+        "division": "C"
+    },
+    {
+        "game_id": 8,
+        "game_slot": 8,
+        "team1": "Team 15",
+        "team2": "Team 16",
+        "date": "2023-10-08",
+        "field": 2,
+        "time": "9:30 PM",
+        "division": "D"
+    }
+]

--- a/src/frontend/src/data/teams.json
+++ b/src/frontend/src/data/teams.json
@@ -1,0 +1,146 @@
+[
+  {
+    "name": "Team 1",
+    "captain": "Derek Li",
+    "paid": false,
+    "division": "D"
+  },
+  {
+    "name": "Team 2",
+    "captain": "Bob",
+    "paid": false,
+    "division": "D"
+  },
+  {
+    "name": "Team 3",
+    "captain": "Derek Li",
+    "paid": true,
+    "division": "D"
+  },
+  {
+    "name": "Team 4",
+    "captain": "Bob",
+    "paid": true,
+    "division": "D"
+  },
+  {
+    "name": "Team 5",
+    "captain": "Derek Li",
+    "paid": true,
+    "division": "D"
+  },
+  {
+    "name": "Team 6",
+    "captain": "Bob",
+    "paid": true,
+    "division": "D"
+  },
+  {
+    "name": "Team 7",
+    "captain": "Derek Li",
+    "paid": true,
+    "division": "C"
+  },
+  {
+    "name": "Team 8",
+    "captain": "Bob",
+    "paid": true,
+    "division": "C"
+  },
+  {
+    "name": "Team 9",
+    "captain": "Derek Li",
+    "paid": false,
+    "division": "C"
+  },
+  {
+    "name": "Team 10",
+    "captain": "Bob",
+    "paid": true,
+    "division": "C"
+  },
+  {
+    "name": "Team 11",
+    "captain": "Derek Li",
+    "paid": true,
+    "division": "C"
+  },
+  {
+    "name": "Team 12",
+    "captain": "Bob",
+    "paid": true,
+    "division": "C"
+  },
+  {
+    "name": "Team 13",
+    "captain": "Derek Li",
+    "paid": true,
+    "division": "C"
+  },
+  {
+    "name": "Team 14",
+    "captain": "Bob",
+    "paid": true,
+    "division": "B"
+  },
+  {
+    "name": "Team 15",
+    "captain": "Derek Li",
+    "paid": true,
+    "division": "B"
+  },
+  {
+    "name": "Team 16",
+    "captain": "Bob",
+    "paid": true,
+    "division": "B"
+  },
+  {
+    "name": "Team 17",
+    "captain": "Derek Li",
+    "paid": true,
+    "division": "B"
+  },
+  {
+    "name": "Team 18",
+    "captain": "Bob",
+    "paid": true,
+    "division": "B"
+  },
+  {
+    "name": "Team 19",
+    "captain": "Derek Li",
+    "paid": true,
+    "division": "A"
+  },
+  {
+    "name": "Team 20",
+    "captain": "Bob",
+    "paid": false,
+    "division": "A"
+  },
+  {
+    "name": "Team 21",
+    "captain": "Derek Li",
+    "paid": false,
+    "division": "A"
+  },
+  {
+    "name": "Team 22",
+    "captain": "Bob",
+    "paid": true,
+    "division": "A"
+  },
+  {
+    "name": "Team 23",
+    "captain": "Derek Li",
+    "paid": true,
+    "division": "A"
+  },
+  {
+    "name": "Team 24",
+    "captain": "Bob",
+    "paid": true,
+    "division": "A"
+  }
+]

--- a/src/frontend/src/routes.js
+++ b/src/frontend/src/routes.js
@@ -1,11 +1,13 @@
-import HomePage from './views/HomePage';
-import LoginPage from './views/LoginPage';
-import MyTeamPage from './views/MyTeamPage';
+import HomePage from "./views/HomePage";
+import LeagueManagementPage from "./views/LeagueManagementPage";
+import LoginPage from "./views/LoginPage";
+import MyTeamPage from "./views/MyTeamPage";
 
 const routes = [
-  { path: '/home', component: HomePage },
-  { path: '/', component: LoginPage },
-  { path: '/team', component: MyTeamPage },
+  { path: "/home", component: HomePage },
+  { path: "/", component: LoginPage },
+  { path: "/team", component: MyTeamPage },
+  { path: "/manage", component: LeagueManagementPage },
 ];
 
 export default routes;

--- a/src/frontend/src/views/LeagueManagementPage.jsx
+++ b/src/frontend/src/views/LeagueManagementPage.jsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { useState } from "react";
+import {
+  Typography,
+  Container,
+  Paper,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+} from "@mui/material";
+import NavBar from "../components/NavBar";
+import teams from "../data/teams";
+import TeamTable from "../components/TeamTable";
+import schedule from "../data/schedule";
+import ScheduleTable from "../components/ScheduleTable";
+
+const divisions = [
+  { id: "A", name: "A" },
+  { id: "B", name: "B" },
+  { id: "C", name: "C" },
+  { id: "D", name: "D" },
+];
+
+const columns = [
+  { header: "Game ID", key: "game_id" },
+  { header: "Date", key: "date" },
+  { header: "Field", key: "field" },
+  { header: "Time", key: "time" },
+  { header: "Team 1", key: "team1" },
+  { header: "Team 2", key: "team2" },
+  { header: "Division", key: "division" },
+  { header: "Result", key: "result" },
+  { header: "Score", key: "score" },
+];
+
+const LeagueManagementPage = () => {
+  const [openLaunchDialog, setOpenLaunchDialog] = useState(false);
+  const [seasonName, setSeasonName] = useState("");
+
+  const handleGenerateSchedule = () => {
+    // Implement schedule generation logic here
+    // call api to generate schedule
+  };
+
+  const handleLaunchSeason = () => {
+    // Implement season launch logic here
+    console.log(`Launching season: ${seasonName}`);
+    setOpenLaunchDialog(false);
+  };
+
+  return (
+    <>
+      <NavBar />
+      <Container maxWidth="lg" sx={{ mt: 4 }}>
+        <Typography variant="h5" gutterBottom sx={{ mb: 2 }}>
+          League Management
+        </Typography>
+        <Paper sx={{ p: 2, mb: 4 }}>
+          <TextField
+            label="Start Date"
+            type="date"
+            InputLabelProps={{
+              shrink: true,
+            }}
+            sx={{ mr: 2 }}
+          />
+          <TextField
+            label="End Date"
+            type="date"
+            InputLabelProps={{
+              shrink: true,
+            }}
+          />
+
+          <Typography variant="h6" gutterBottom sx={{ mb: 2, mt: 2 }}>
+            Registered Teams{" "}
+          </Typography>
+          <TeamTable teams={teams} divisions={divisions} />
+
+          <Button
+            variant="contained"
+            sx={{ ml: 2, backgroundColor: "#7A003C" }}
+            onClick={() => handleGenerateSchedule()}
+          >
+            Generate Schedule
+          </Button>
+        </Paper>
+        <Typography variant="h5" gutterBottom sx={{ mb: 2 }}>
+          Schedule
+        </Typography>
+        <Paper sx={{ p: 2 }}>
+          <ScheduleTable columns={columns} data={schedule} />
+          <Button
+            variant="contained"
+            sx={{ ml: 2, backgroundColor: "#7A003C" }}
+            onClick={() => setOpenLaunchDialog(true)}
+          >
+            Launch New Season
+          </Button>
+        </Paper>
+      </Container>
+
+      <Dialog
+        open={openLaunchDialog}
+        onClose={() => setOpenLaunchDialog(false)}
+      >
+        <DialogTitle>Launch New Season</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            margin="dense"
+            id="seasonName"
+            label="Season Name"
+            type="text"
+            fullWidth
+            variant="standard"
+            value={seasonName}
+            onChange={(e) => setSeasonName(e.target.value)}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpenLaunchDialog(false)}>Cancel</Button>
+          <Button onClick={handleLaunchSeason}>Launch</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default LeagueManagementPage;

--- a/src/frontend/src/views/MyTeamPage.jsx
+++ b/src/frontend/src/views/MyTeamPage.jsx
@@ -7,6 +7,13 @@ import NotificationsRow from "../components/NotificationsRow";
 import temp_team_info from "../data/team.json";
 
 export default function MyTeamPage() {
+  const columns = [
+    { header: "Date", key: "date" },
+    { header: "Opposing Team", key: "team" },
+    { header: "Result", key: "result" },
+    { header: "Score", key: "score" },
+  ];
+
   return (
     <div className="min-h-screen bg-gray-50">
       <NavBar />
@@ -67,7 +74,7 @@ export default function MyTeamPage() {
         <Typography variant="h5" component="h2" gutterBottom>
           Games
         </Typography>
-        <ScheduleTable games={temp_team_info.schedule} />
+        <ScheduleTable columns={columns} data={temp_team_info.schedule} />
 
         {/* TODO - add submit score for captain */}
         {/* <Box sx={{ display: "flex", justifyContent: "flex-end" }}>


### PR DESCRIPTION
### changes

Don't think we have a complete figma for this, so I went off of our conversations with Dr. Nease

At `/manage` there is a league management page where commissioner can edit registered team divisions and check payments. Also this is where the commish will generate a schedule and start season.

<img width="1468" alt="image" src="https://github.com/user-attachments/assets/639601a4-916a-4fbd-9a0a-1c1888133ec7" />
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/c490f320-a595-44f2-bf23-35436404052b" />

The generate schedule still requires the backend connection so this is using dummy data currently. I have implemented the checkboxes and division select to alter the teams dummy data.