### PR TITLE
Generate Schedule + Launch Season

### DIFF
--- a/src/backend/controllers/schedule-controller.js
+++ b/src/backend/controllers/schedule-controller.js
@@ -209,7 +209,10 @@ const getScheduleBySeasonId = async (req, res, next) => {
 
   let schedule;
   try {
-    schedule = await Schedule.findOne({ seasonId: seasonId }).populate("games");
+    schedule = await Schedule.findOne({ seasonId: seasonId }).populate({
+      path: "games",
+      populate: [{ path: "team1" }, { path: "team2" }, { path: "division" }],
+    });
   } catch (err) {
     const error = new HttpError(
       "Fetching schedule failed, please try again later.",

--- a/src/backend/controllers/season-controllers.js
+++ b/src/backend/controllers/season-controllers.js
@@ -12,10 +12,7 @@ const getUpcomingSeasons = async (req, res, next) => {
       })
       .populate({
         path: "registeredTeams",
-        populate: [
-          { path: "captainId" }, 
-          { path: "roster" }, 
-        ],
+        populate: [{ path: "captainId" }, { path: "roster" }],
       });
   } catch (err) {
     const error = new HttpError(
@@ -38,10 +35,7 @@ const getOngoingSeasons = async (req, res, next) => {
       })
       .populate({
         path: "registeredTeams",
-        populate: [
-          { path: "captainId" }, 
-          { path: "roster" },
-        ],
+        populate: [{ path: "captainId" }, { path: "roster" }],
       });
   } catch (err) {
     const error = new HttpError(
@@ -64,10 +58,7 @@ const getArchivedSeasons = async (req, res, next) => {
       })
       .populate({
         path: "registeredTeams",
-        populate: [
-          { path: "captainId" },
-          { path: "roster" }, 
-        ],
+        populate: [{ path: "captainId" }, { path: "roster" }],
       });
   } catch (err) {
     const error = new HttpError(
@@ -161,10 +152,7 @@ const getAllSeasons = async (req, res, next) => {
       })
       .populate({
         path: "registeredTeams",
-        populate: [
-          { path: "captainId" }, 
-          { path: "roster" }, 
-        ],
+        populate: [{ path: "captainId" }, { path: "roster" }],
       });
   } catch (err) {
     const error = new HttpError(
@@ -215,16 +203,13 @@ const getSeasonById = async (req, res, next) => {
 
   let season;
   try {
-    season = await Season.find(seasonId)
+    season = await Season.findById(seasonId)
       .populate({
         path: "divisions",
       })
       .populate({
         path: "registeredTeams",
-        populate: [
-          { path: "captainId" }, 
-          { path: "roster" },
-        ],
+        populate: [{ path: "captainId" }, { path: "roster" }],
       });
   } catch (err) {
     const error = new HttpError(

--- a/src/backend/controllers/season-controllers.js
+++ b/src/backend/controllers/season-controllers.js
@@ -6,7 +6,17 @@ const Division = require("../models/division");
 const getUpcomingSeasons = async (req, res, next) => {
   let seasons;
   try {
-    seasons = await Season.find({ status: "upcoming" }).populate("divisions registeredTeams");;
+    seasons = await Season.find({ status: "upcoming" })
+      .populate({
+        path: "divisions",
+      })
+      .populate({
+        path: "registeredTeams",
+        populate: [
+          { path: "captainId" }, 
+          { path: "roster" }, 
+        ],
+      });
   } catch (err) {
     const error = new HttpError(
       "Fetching open seasons failed, please try again later.",
@@ -22,7 +32,17 @@ const getUpcomingSeasons = async (req, res, next) => {
 const getOngoingSeasons = async (req, res, next) => {
   let seasons;
   try {
-    seasons = await Season.find({ status: "ongoing" }).populate("divisions registeredTeams");;
+    seasons = await Season.find({ status: "ongoing" })
+      .populate({
+        path: "divisions",
+      })
+      .populate({
+        path: "registeredTeams",
+        populate: [
+          { path: "captainId" }, 
+          { path: "roster" },
+        ],
+      });
   } catch (err) {
     const error = new HttpError(
       "Fetching ongoing seasons failed, please try again later.",
@@ -38,7 +58,17 @@ const getOngoingSeasons = async (req, res, next) => {
 const getArchivedSeasons = async (req, res, next) => {
   let seasons;
   try {
-    seasons = await Season.find({ status: "archived" }).populate("divisions registeredTeams");;
+    seasons = await Season.find({ status: "archived" })
+      .populate({
+        path: "divisions",
+      })
+      .populate({
+        path: "registeredTeams",
+        populate: [
+          { path: "captainId" },
+          { path: "roster" }, 
+        ],
+      });
   } catch (err) {
     const error = new HttpError(
       "Fetching archived seasons failed, please try again later.",
@@ -125,7 +155,17 @@ const createSeason = async (req, res, next) => {
 const getAllSeasons = async (req, res, next) => {
   let seasons;
   try {
-    seasons = await Season.find().populate("divisions registeredTeams");
+    seasons = await Season.find()
+      .populate({
+        path: "divisions",
+      })
+      .populate({
+        path: "registeredTeams",
+        populate: [
+          { path: "captainId" }, 
+          { path: "roster" }, 
+        ],
+      });
   } catch (err) {
     const error = new HttpError(
       "Fetching seasons failed, please try again later.",
@@ -175,7 +215,17 @@ const getSeasonById = async (req, res, next) => {
 
   let season;
   try {
-    season = await Season.findById(seasonId).populate("divisions registeredTeams");;
+    season = await Season.find(seasonId)
+      .populate({
+        path: "divisions",
+      })
+      .populate({
+        path: "registeredTeams",
+        populate: [
+          { path: "captainId" }, 
+          { path: "roster" },
+        ],
+      });
   } catch (err) {
     const error = new HttpError(
       "Fetching season failed, please try again later.",
@@ -254,6 +304,40 @@ const updateSeasonDivisionTeams = async (req, res, next) => {
   res.status(200).json({ season: season.toObject({ getters: true }) });
 };
 
+const updateToOngoingSeason = async (req, res, next) => {
+  const seasonId = req.params.sid;
+
+  let season;
+  try {
+    season = await Season.findById(seasonId);
+  } catch (err) {
+    const error = new HttpError(
+      "Something went wrong, could not update season.",
+      500
+    );
+    return next(error);
+  }
+
+  if (!season) {
+    const error = new HttpError("Could not find season for this id.", 404);
+    return next(error);
+  }
+
+  season.status = "ongoing";
+
+  try {
+    await season.save();
+  } catch (err) {
+    const error = new HttpError(
+      "Something went wrong, could not update season.",
+      500
+    );
+    return next(error);
+  }
+
+  res.status(200).json({ season: season.toObject({ getters: true }) });
+};
+
 exports.getUpcomingSeasons = getUpcomingSeasons;
 exports.getOngoingSeasons = getOngoingSeasons;
 exports.getArchivedSeasons = getArchivedSeasons;
@@ -262,3 +346,4 @@ exports.getAllSeasons = getAllSeasons;
 exports.deleteSeason = deleteSeason;
 exports.getSeasonById = getSeasonById;
 exports.updateSeasonDivisionTeams = updateSeasonDivisionTeams;
+exports.updateToOngoingSeason = updateToOngoingSeason;

--- a/src/backend/routes/season-routes.js
+++ b/src/backend/routes/season-routes.js
@@ -36,4 +36,6 @@ router.get("/:sid", seasonController.getSeasonById);
 
 router.patch("/:sid/divisionTeams", seasonController.updateSeasonDivisionTeams);
 
+router.patch("/:sid/launch", seasonController.updateToOngoingSeason);
+
 module.exports = router;

--- a/src/frontend/src/api/schedule.js
+++ b/src/frontend/src/api/schedule.js
@@ -23,3 +23,25 @@ export const generateSchedule = async (seasonId) => {
     throw error;
   }
 };
+
+export const getScheduleBySeasonId = async (seasonId) => {
+  try {
+    const response = await fetch(
+      `${REACT_APP_API_BASE_URL}/schedules/season/${seasonId}`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error("Failed to get schedule");
+    }
+    return await response.json();
+  } catch (error) {
+    console.error("Error getting schedule:", error);
+    throw error;
+  }
+};

--- a/src/frontend/src/api/season.js
+++ b/src/frontend/src/api/season.js
@@ -157,7 +157,6 @@ export async function getSeasonById(id) {
 
 export async function updateSeasonDivisionTeams(id, divisions) {
   try {
-    console.log(JSON.stringify({ divisions }));
     const response = await fetch(
       `${REACT_APP_API_BASE_URL}/seasons/${id}/divisionTeams`,
       {
@@ -173,6 +172,31 @@ export async function updateSeasonDivisionTeams(id, divisions) {
     if (!response.ok) {
       const error = await response.json();
       throw new Error(error.message || "Update season division teams failed");
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    throw error;
+  }
+}
+
+export async function launchSeason(seasonId) {
+  try {
+    const response = await fetch(
+      `${REACT_APP_API_BASE_URL}/seasons/${seasonId}/launch`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+
+    console.log("Launch Season response:", response);
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.message || "Launch season failed");
     }
 
     const data = await response.json();

--- a/src/frontend/src/components/DivisionCard.jsx
+++ b/src/frontend/src/components/DivisionCard.jsx
@@ -10,7 +10,7 @@ export const DivisionCard = (props) => {
         </Typography>
         <Box sx={{ mt: 2, overflowY: "auto", height: "120px" }}>
           {(props.tempTeams || [])
-            .filter((team) => team.division == props.division.id)
+            .filter((team) => team.divisionId == props.division.id)
             .map((team, index) => (
               <Typography key={index} variant="body2" color="text.secondary">
                 {team.name}

--- a/src/frontend/src/components/NavBar.js
+++ b/src/frontend/src/components/NavBar.js
@@ -92,9 +92,7 @@ const NavBar = () => {
           <Box sx={{ ml: "auto" }}>
             <IconButton color="inherit" size="large" onClick={handleIconClick}>
               <Typography sx={{ mr: 1 }}>
-                {player
-                  ? `${player.firstName} ${player.lastName}`
-                  : "TEMP (not logged in)"}
+                {player ? `${player.firstName} ${player.lastName}` : ""}
               </Typography>
               <PersonIcon />
             </IconButton>

--- a/src/frontend/src/components/ScheduleTable.jsx
+++ b/src/frontend/src/components/ScheduleTable.jsx
@@ -8,30 +8,63 @@ import {
   TableHead,
   TableRow,
 } from "@mui/material";
+import { formatDate } from "../utils/Formatting";
 
 export default function ScheduleTable(props) {
-  return (
-    <TableContainer component={Paper} sx={{ mb: 6, maxHeight: "50vh" }}>
+  // Define columns
+  const columns = [
+    {
+      header: "Date",
+      accessor: (game) => formatDate(game.date),
+    },
+    { header: "Time", accessor: (game) => game.time },
+    { header: "Field", accessor: (game) => game.field },
+    { header: "Division", accessor: (game) => game.division.name },
+    { header: "Team 1", accessor: (game) => game.team1.name },
+    { header: "Team 2", accessor: (game) => game.team2.name },
+    {
+      header: "Score",
+      accessor: (game) =>
+        game.score1 !== undefined && game.score2 !== undefined
+          ? `${game.score1} - ${game.score2}`
+          : "",
+    },
+  ];
+
+  return props.schedule ? (
+    <TableContainer component={Paper} sx={{ mb: 2, maxHeight: "50vh" }}>
       <Table stickyHeader>
         <TableHead>
           <TableRow>
-            {props.columns.map((column, index) => (
+            {/* Map over columns for headers */}
+            {columns.map((column, index) => (
               <TableCell key={index}>{column.header}</TableCell>
             ))}
           </TableRow>
         </TableHead>
         <TableBody>
-          {props.data.map((row, rowIndex) => (
-            <TableRow key={rowIndex}>
-              {props.columns.map((column, colIndex) => (
-                <TableCell key={colIndex} sx={{ height: 12 }}>
-                  {column.accessor ? column.accessor(row) : row[column.key]}
-                </TableCell>
-              ))}
+          {/* Map through the games */}
+          {props.schedule.games && props.schedule.games.length > 0 ? (
+            props.schedule.games.map((game, index) => (
+              <TableRow key={index}>
+                {columns.map((column, colIndex) => (
+                  <TableCell key={colIndex} sx={{ height: 12 }}>
+                    {column.accessor(game)}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columns.length} align="center">
+                No games scheduled.
+              </TableCell>
             </TableRow>
-          ))}
+          )}
         </TableBody>
       </Table>
     </TableContainer>
+  ) : (
+    <>No Schedule Table to Display</>
   );
 }

--- a/src/frontend/src/components/TeamTable.jsx
+++ b/src/frontend/src/components/TeamTable.jsx
@@ -36,10 +36,9 @@ export default function TeamTable(props) {
   const [teamToDelete, setTeamToDelete] = useState(null);
 
   const handleDivisionChange = (teamId, newDivisionId) => {
-    console.log(`Changing division for team ${teamId} to ${newDivisionId}`);
     const updatedTeams = props.tempTeams.map((team) => {
       if (team.id === teamId) {
-        return { ...team, division: newDivisionId };
+        return { ...team, divisionId: newDivisionId };
       }
       return team;
     });
@@ -75,8 +74,30 @@ export default function TeamTable(props) {
 
   function getPreferredDivision(refTeam) {
     const team = props.registeredTeams.find((team) => team.id === refTeam.id);
-    return team && team.division ? team.division : null;
+    return team && team.divisionId ? team.divisionId : null;
   }
+
+  const columns = [
+    { label: "Team Name", accessor: (team) => team.name },
+    {
+      label: "Captain",
+      accessor: (team) =>
+        `${team.captainId.firstName} ${team.captainId.lastName}`,
+    },
+    { label: "Captain Email", accessor: (team) => team.captainId.email },
+    { label: "Roster Size", accessor: (team) => team.roster.length },
+
+    { label: "Preferred Times", accessor: (team) => team.preferredTimes },
+    {
+      label: "Blacklist Days",
+      accessor: (team) =>
+        team.blacklistDays.length > 0 ? team.blacklistDays.join(", ") : "None",
+    },
+    {
+      label: "Preferred Division",
+      accessor: (team) => getDivisionName(getPreferredDivision(team)),
+    },
+  ];
 
   return (
     <>
@@ -84,14 +105,10 @@ export default function TeamTable(props) {
         <Table stickyHeader aria-label="team management table" size="small">
           <TableHead>
             <TableRow>
-              <TableCell>Team Name</TableCell>
-              <TableCell>Captain</TableCell>
-              <TableCell>Captain Email</TableCell>
-              <TableCell>Roster Size</TableCell>
-              <TableCell>Preferred Division</TableCell>
+              {columns.map((col, index) => (
+                <TableCell key={index}>{col.label}</TableCell>
+              ))}
               <TableCell>Division</TableCell>
-              <TableCell>Preferred Times</TableCell>
-              <TableCell>Blacklist Days</TableCell>
               <TableCell>Payment Status</TableCell>
               <TableCell>Actions</TableCell>
             </TableRow>
@@ -99,18 +116,14 @@ export default function TeamTable(props) {
           <TableBody>
             {(props.tempTeams || []).map((team) => (
               <TableRow key={team.id}>
-                <TableCell>{team.name}</TableCell>
-                <TableCell>{team.captain}</TableCell>
-                <TableCell>{team.captain}@email.com</TableCell>
-                <TableCell>{team.roster.length}</TableCell>
-                <TableCell>
-                  {getDivisionName(getPreferredDivision(team))}
-                </TableCell>
+                {columns.map((col, index) => (
+                  <TableCell key={index}>{col.accessor(team)}</TableCell>
+                ))}
                 <TableCell>
                   <Select
-                    defaultValue={team.division}
-                    value={team.division}
-                    label={getDivisionName(team.division)}
+                    defaultValue={team.divisionId}
+                    value={team.divisionId}
+                    label={getDivisionName(team.divisionId)}
                     onChange={(e) =>
                       handleDivisionChange(team.id, e.target.value)
                     }
@@ -123,8 +136,6 @@ export default function TeamTable(props) {
                     ))}
                   </Select>
                 </TableCell>
-                <TableCell>{team.preferredTimes}</TableCell>
-                <TableCell>{team.blacklistDays}</TableCell>
                 <TableCell>
                   <FormControlLabel
                     control={

--- a/src/frontend/src/data/schedule.json
+++ b/src/frontend/src/data/schedule.json
@@ -1,82 +1,84 @@
-[
+{
+  "games": [
     {
-        "game_id": 1,
-        "game_slot": 1,
-        "team1": "Team 1",
-        "team2": "Team 2",
-        "date": "2023-10-01",
-        "field": 1,
-        "time": "5:00 PM",
-        "division": "A"
+      "game_id": 1,
+      "game_slot": 1,
+      "team1": { "name": "Team 1" },
+      "team2": { "name": "Team 2" },
+      "date": "2023-10-01",
+      "field": 1,
+      "time": "5:00 PM",
+      "division": { "name": "A" }
     },
     {
-        "game_id": 2,
-        "game_slot": 2,
-        "team1": "Team 3",
-        "team2": "Team 4",
-        "date": "2023-10-01",
-        "field": 2,
-        "time": "6:30 PM",
-        "division": "B"
+      "game_id": 2,
+      "game_slot": 2,
+      "team1": { "name": "Team 3" },
+      "team2": { "name": "Team 4" },
+      "date": "2023-10-01",
+      "field": 2,
+      "time": "6:30 PM",
+      "division": { "name": "B" }
     },
     {
-        "game_id": 3,
-        "game_slot": 3,
-        "team1": "Team 5",
-        "team2": "Team 6",
-        "date": "2023-10-01",
-        "field": 3,
-        "time": "8:00 PM",
-        "division": "C"
+      "game_id": 3,
+      "game_slot": 3,
+      "team1": { "name": "Team 5" },
+      "team2": { "name": "Team 6" },
+      "date": "2023-10-01",
+      "field": 3,
+      "time": "8:00 PM",
+      "division": { "name": "C" }
     },
     {
-        "game_id": 4,
-        "game_slot": 4,
-        "team1": "Team 7",
-        "team2": "Team 8",
-        "date": "2023-10-01",
-        "field": 1,
-        "time": "9:30 PM",
-        "division": "D"
+      "game_id": 4,
+      "game_slot": 4,
+      "team1": { "name": "Team 7" },
+      "team2": { "name": "Team 8" },
+      "date": "2023-10-01",
+      "field": 1,
+      "time": "9:30 PM",
+      "division": { "name": "D" }
     },
     {
-        "game_id": 5,
-        "game_slot": 5,
-        "team1": "Team 9",
-        "team2": "Team 10",
-        "date": "2023-10-08",
-        "field": 2,
-        "time": "5:00 PM",
-        "division": "A"
+      "game_id": 5,
+      "game_slot": 5,
+      "team1": { "name": "Team 9" },
+      "team2": { "name": "Team 10" },
+      "date": "2023-10-08",
+      "field": 2,
+      "time": "5:00 PM",
+      "division": { "name": "A" }
     },
     {
-        "game_id": 6,
-        "game_slot": 6,
-        "team1": "Team 11",
-        "team2": "Team 12",
-        "date": "2023-10-08",
-        "field": 3,
-        "time": "6:30 PM",
-        "division": "B"
+      "game_id": 6,
+      "game_slot": 6,
+      "team1": { "name": "Team 11" },
+      "team2": { "name": "Team 12" },
+      "date": "2023-10-08",
+      "field": 3,
+      "time": "6:30 PM",
+      "division": { "name": "B" }
     },
     {
-        "game_id": 7,
-        "game_slot": 7,
-        "team1": "Team 13",
-        "team2": "Team 14",
-        "date": "2023-10-08",
-        "field": 1,
-        "time": "8:00 PM",
-        "division": "C"
+      "game_id": 7,
+      "game_slot": 7,
+      "team1": { "name": "Team 13" },
+      "team2": { "name": "Team 14" },
+      "date": "2023-10-08",
+      "field": 1,
+      "time": "8:00 PM",
+      "division": { "name": "C" }
     },
     {
-        "game_id": 8,
-        "game_slot": 8,
-        "team1": "Team 15",
-        "team2": "Team 16",
-        "date": "2023-10-08",
-        "field": 2,
-        "time": "9:30 PM",
-        "division": "D"
+      "game_id": 8,
+      "game_slot": 8,
+      "team1": { "name": "Team 15" },
+      "team2": { "name": "Team 16" },
+      "date": "2023-10-08",
+      "field": 2,
+      "time": "9:30 PM",
+      "division": { "name": "D" }
     }
-]
+  ]
+}

--- a/src/frontend/src/views/AnnouncementsPage.jsx
+++ b/src/frontend/src/views/AnnouncementsPage.jsx
@@ -27,10 +27,6 @@ export default function AnnouncementPage({ userRole = "commissioner" }) {
     fetchAnnouncements();
   }, []);
 
-  if (!selectedAnnouncement || announcements.length === 0) {
-    return <Typography>Loading...</Typography>;
-  }
-
   // to exclude the selected announcement from past announcements
   // (if user has selected READ MORE from past announcement list)
   const pastAnnouncements = announcements.filter(
@@ -41,70 +37,76 @@ export default function AnnouncementPage({ userRole = "commissioner" }) {
   return (
     <Box sx={{ bgcolor: "background.default", minHeight: "100vh", display: "flex", flexDirection: "column" }}>
       <NavBar />
-      <Container maxWidth="lg" sx={{ py: 6, flexGrow: 1 }}>
-        {/* Commissioner Controls */}
-        {userRole === "commissioner" && (
-          <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 4 }}>
-            <Button
-              variant="contained"
-              sx={{ borderRadius: 2, backgroundColor: "#7A003C", "&:hover": { backgroundColor: "#59002B" } }}
-              onClick={() => navigate("/announcements/create")}
-            >
-              Create New Announcement
-            </Button>
-          </Box>
-        )}
+      {!selectedAnnouncement || announcements.length === 0 ? (
+        <Typography sx={{ p: 5 }}>Loading...</Typography>
+      ) : (
+        <>
+          <Container maxWidth="lg" sx={{ py: 6, flexGrow: 1 }}>
+            {/* Commissioner Controls */}
+            {userRole === "commissioner" && (
+              <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 4 }}>
+                <Button
+                  variant="contained"
+                  sx={{ borderRadius: 2, backgroundColor: "#7A003C", "&:hover": { backgroundColor: "#59002B" } }}
+                  onClick={() => navigate("/announcements/create")}
+                >
+                  Create New Announcement
+                </Button>
+              </Box>
+            )}
 
-        {/* Main Announcement */}
-        <Box sx={{ py: 2 }}>
-          <Typography 
-          variant="h3" 
-          align="center" 
-          gutterBottom
-          sx={{
-            fontSize: { xs: "3rem", md: "4rem" },
-            fontWeight: 900,
-          }}
-          >
-            {selectedAnnouncement.title}
-          </Typography>
-          <Typography align="center" color="text.secondary" gutterBottom>
-            {new Date(selectedAnnouncement.createdAt).toLocaleDateString()}
-          </Typography>
-          <Typography 
-          paragraph
-          sx={{
-            fontSize: { md: "1.2rem" },
-          }}
-          >
-            {selectedAnnouncement.content}</Typography>
-
-          {/* Edit Button for Main Announcement */}
-          {userRole === "commissioner" && (
-            <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 2 }}>
-              <Button
-                variant="contained"
-                sx={{ 
-                  borderRadius: 2, 
-                  backgroundColor: "#7A003C", "&:hover": 
-                  { backgroundColor: "#59002B" } 
+            {/* Main Announcement */}
+            <Box sx={{ py: 2 }}>
+              <Typography
+                variant="h3"
+                align="center"
+                gutterBottom
+                sx={{
+                  fontSize: { xs: "3rem", md: "4rem" },
+                  fontWeight: 900,
                 }}
-                onClick={() => navigate(`/announcements/edit/${selectedAnnouncement._id}`)}
-                startIcon={<EditIcon />}
               >
-                Edit
-              </Button>
-            </Box>
-          )}
-        </Box>
-      </Container>
+                {selectedAnnouncement.title}
+              </Typography>
+              <Typography align="center" color="text.secondary" gutterBottom>
+                {new Date(selectedAnnouncement.createdAt).toLocaleDateString()}
+              </Typography>
+              <Typography
+                paragraph
+                sx={{
+                  fontSize: { md: "1.2rem" },
+                }}
+              >
+                {selectedAnnouncement.content}</Typography>
 
-      {/* Past Announcements Section */}
-      <PastAnnouncementsSection
-        pastAnnouncements={pastAnnouncements}
-        userRole={userRole}
-        onReadMore={setSelectedAnnouncement} // Pass function to update the main announcement
-      />
+              {/* Edit Button for Main Announcement */}
+              {userRole === "commissioner" && (
+                <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 2 }}>
+                  <Button
+                    variant="contained"
+                    sx={{
+                      borderRadius: 2,
+                      backgroundColor: "#7A003C", "&:hover": 
+                      { backgroundColor: "#59002B" }
+                    }}
+                    onClick={() => navigate(`/announcements/edit/${selectedAnnouncement._id}`)}
+                    startIcon={<EditIcon />}
+                  >
+                    Edit
+                  </Button>
+                </Box>
+              )}
+            </Box>
+          </Container>
+
+          {/* Past Announcements Section */}
+          <PastAnnouncementsSection
+            pastAnnouncements={pastAnnouncements}
+            userRole={userRole}
+            onReadMore={setSelectedAnnouncement} // Pass function to update the main announcement
+          />
+        </>
+      )}
     </Box>
   );
 }

--- a/src/frontend/src/views/HomePage.jsx
+++ b/src/frontend/src/views/HomePage.jsx
@@ -134,10 +134,9 @@ export default function HomePage() {
                 Welcome to the McMaster Graduate Students Association Softball
                 League!
               </Typography>
-              <Accordion>
+              <Accordion defaultExpanded={true}>
                 <AccordionSummary
                   expandIcon={<ArrowDropDownIcon />}
-                  aria-controls="panel1-content"
                   id="upcoming-header"
                 >
                   <Typography component="span">Upcoming Seasons</Typography>
@@ -155,17 +154,6 @@ export default function HomePage() {
                 </AccordionSummary>
                 <AccordionDetails>
                   <SeasonsCard seasons={ongoingSeasons} status="Ongoing" />
-                </AccordionDetails>
-              </Accordion>
-              <Accordion>
-                <AccordionSummary
-                  expandIcon={<ArrowDropDownIcon />}
-                  id="archived-header"
-                >
-                  <Typography component="span">Archived Seasons</Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <SeasonsCard seasons={archivedSeasons} status="Archived" />
                 </AccordionDetails>
               </Accordion>
             </Grid>
@@ -202,19 +190,19 @@ export default function HomePage() {
                   <Grid item xs={12} md={4} key={announcement._id}>
                     <StyledCard>
                       <CardContent sx={{ 
-                        flexGrow: 1,
-                        display: "flex",
-                        flexDirection: "column",
-                        justifyContent: "space-between"
-                        }}
-                        >
-                        <Typography 
-                        gutterBottom 
-                        variant="h4" 
-                        component="h2"
-                        sx={{
-                          fontWeight: 700,
-                        }}
+                          flexGrow: 1,
+                          display: "flex",
+                          flexDirection: "column",
+                          justifyContent: "space-between"
+                          }}
+                      >
+                        <Typography
+                          gutterBottom
+                          variant="h4"
+                          component="h2"
+                          sx={{
+                            fontWeight: 700,
+                          }}
                         >
                           {announcement.title}
                         </Typography>
@@ -234,7 +222,6 @@ export default function HomePage() {
                               bgcolor: "#7A003C",
                               opacity: 0.9,
                             },
-                            
                           }}
                           onClick={() => navigate(`/announcements`, { state: {selectedAnnouncement: announcement} })}
                         >
@@ -245,7 +232,7 @@ export default function HomePage() {
                   </Grid>
                 ))
               )}
-           </Grid>
+            </Grid>
           </Container>
         </Box>
       </Box>

--- a/src/frontend/src/views/LeagueManagementPage.jsx
+++ b/src/frontend/src/views/LeagueManagementPage.jsx
@@ -39,8 +39,6 @@ const columns = [
 ];
 
 const LeagueManagementPage = () => {
-  const [teams, setTeams] = useState(teamsData);
-
   // Season state values
   const [upcomingSeasons, setUpcomingSeasons] = useState(null);
   const [ongoingSeasons, setOngoingSeasons] = useState(null);
@@ -142,9 +140,8 @@ const LeagueManagementPage = () => {
                       <TeamSchedulingComponent
                         // registeredTeamsIds={season.registeredTeams}
                         season={season}
-                        teams={teams}
-                        setTeams={setTeams}
                         divisions={season.divisions}
+                        registeredTeams={season.registeredTeams}
                       />
                     </AccordionDetails>
                   </Accordion>

--- a/src/frontend/src/views/MyTeamPage.jsx
+++ b/src/frontend/src/views/MyTeamPage.jsx
@@ -5,6 +5,7 @@ import ScheduleTable from "../components/ScheduleTable";
 import GamesRow from "../components/GamesRow";
 import NotificationsRow from "../components/NotificationsRow";
 import temp_team_info from "../data/team.json";
+import dummySchedule from "../data/schedule.json";
 import { useAuth } from "../hooks/AuthProvider";
 import { getPlayerById } from "../api/player";
 import { useEffect, useState } from "react";
@@ -116,7 +117,7 @@ export default function MyTeamPage() {
         <Typography variant="h4" component="h2" gutterBottom>
           Games
         </Typography>
-        <ScheduleTable columns={columns} data={temp_team_info.schedule} />
+        <ScheduleTable schedule={dummySchedule}/>
 
         {/* TODO - add submit score for captain */}
         {/* <Box sx={{ display: "flex", justifyContent: "flex-end" }}>

--- a/src/frontend/src/views/MyTeamPage.jsx
+++ b/src/frontend/src/views/MyTeamPage.jsx
@@ -45,6 +45,7 @@ export default function MyTeamPage() {
       <NavBar />
 
       <Container maxWidth="lg" sx={{ py: 4 }}>
+        {/* Maybe we add a tab for the teams a player is on, and it could be href to /team/:teamId ? */}
         <Typography variant="h4" component="h2" gutterBottom>
           Teams
         </Typography>

--- a/src/frontend/src/views/RegisterTeamPage.jsx
+++ b/src/frontend/src/views/RegisterTeamPage.jsx
@@ -31,7 +31,6 @@ export default function RegisterTeamPage() {
   const [playerId, setPlayerId] = useState(auth.playerId);
   const [player, setPlayer] = useState(null);
   const [season, setSeason] = useState(null);
-  const [divisions, setDivisions] = useState([]);
 
   useEffect(() => {
     const fetchPlayerById = async (pid) => {
@@ -47,8 +46,10 @@ export default function RegisterTeamPage() {
 
     const fetchSeasonById = async (sid) => {
       try {
+        setLoading(true);
         const data = await getSeasonById(sid);
         setSeason(data.season);
+        setLoading(false);
       } catch (err) {
         setError(err.message || "Failed to fetch season");
       } finally {
@@ -59,23 +60,6 @@ export default function RegisterTeamPage() {
     fetchPlayerById(playerId);
     fetchSeasonById(seasonId);
   }, []);
-
-  useEffect(() => {
-    const fetchDivisionById = async (dids) => {
-      try {
-        const data = await getDivisionsById(dids);
-        setDivisions(data.divisions);
-      } catch (err) {
-        setError(err.message || "Failed to fetch divisions");
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    if (season) {
-      fetchDivisionById(season.divisions);
-    }
-  }, [season]);
 
   const handleTeamNameChange = (e) => {
     setTeamName(e.target.value);
@@ -146,8 +130,9 @@ export default function RegisterTeamPage() {
               label="Division"
               required
             >
-              {divisions &&
-                divisions.map((division) => (
+              {season &&
+                season.divisions &&
+                season.divisions.map((division) => (
                   <MenuItem key={division._id} value={division._id}>
                     {division.name}
                   </MenuItem>

--- a/src/frontend/src/views/SchedulePage.jsx
+++ b/src/frontend/src/views/SchedulePage.jsx
@@ -78,7 +78,7 @@ export default function SchedulePage() {
                   </TabList>
                 </Box>
                 <TabPanel value="1">
-                  <ScheduleTable columns={columns} data={schedule} />
+                  <ScheduleTable schedule={schedule} />
                 </TabPanel>
                 <TabPanel value="2">View Two</TabPanel>
                 <TabPanel value="3">View Three</TabPanel>


### PR DESCRIPTION
# Generate/Launch Schedule 
## Overview  
This PR introduces the ability to generate schedules and launch season .
## Changes Included  
- Changed some backend responses to populate some objects. Refactored the frontend accordingly and reduced frontend lookup requests
- Added backend endpoint to launchSeason based on season ID, which changes status: `upcoming` to `ongoing`
- ability to generate and then launch schedyle/season on frontend


# note
i think our (prob me) inconsistency in backend naming might be confusing , sometimes theres "divisionId" and sometimes theres" division" and same with other objects - we should prob change them all some point and this will break some PR