### PR TITLE
Connecting backend to the MyTeamPage

### DIFF
--- a/src/backend/controllers/players-controllers.js
+++ b/src/backend/controllers/players-controllers.js
@@ -167,7 +167,15 @@ const getPlayerById = async (req, res, next) => {
 
   let player;
   try {
-    player = await Player.findById(playerId).populate("team");
+    player = await Player.findById(playerId).populate({
+      path: "team",
+      populate: [
+        { path: "roster" }, // Populate roster with player details
+        { path: "captainId" }, // Populate captain details
+        { path: "divisionId" }, // Populate division details
+        { path: "seasonId" }, // Populate season details
+      ],
+    });
   } catch (err) {
     const error = new HttpError(
       "Fetching player failed, please try again later.",

--- a/src/backend/controllers/teams-controllers.js
+++ b/src/backend/controllers/teams-controllers.js
@@ -89,10 +89,10 @@ const getTeamsById = async (req, res, next) => {
   let teams;
   try {
     teams = await Team.find({ _id: { $in: teamIds } })
-      .populate("divisionId") // Populating division
-      .populate("roster") // Populating the roster of players
-      .populate("captainId") // Populating captain
-      .populate("season"); // Po;
+      .populate("divisionId") 
+      .populate("roster") 
+      .populate("captainId") 
+      .populate("seasonId"); 
   } catch (err) {
     const error = new HttpError(
       "Fetching teams failed, please try again later.",

--- a/src/frontend/src/components/NavBar.js
+++ b/src/frontend/src/components/NavBar.js
@@ -25,11 +25,14 @@ const NavBar = () => {
   const [error, setError] = useState(null);
   const [playerId, setPlayerId] = useState(auth.playerId);
   const [player, setPlayer] = useState(null);
+  const [teamId, setTeamId] = useState("");
+  
   useEffect(() => {
     const fetchPlayerById = async (pid) => {
       try {
         const data = await getPlayerById(pid);
         setPlayer(data.player);
+        setTeamId(data.player.team.id);
         console.log("Upcoming Seasons:", data);
       } catch (err) {
         setError(err.message || "Failed to fetch player");
@@ -76,7 +79,7 @@ const NavBar = () => {
             <Button color="inherit" href="/announcements">
               Announcements
             </Button>
-            <Button color="inherit" href="/team">
+            <Button color="inherit" href={`/team/${teamId}`}>
               My Team
             </Button>
             <Button color="inherit" href="/schedule">

--- a/src/frontend/src/components/NoDataCard.jsx
+++ b/src/frontend/src/components/NoDataCard.jsx
@@ -1,14 +1,15 @@
 import React from "react";
 import { Button, Stack, Container, Typography } from "@mui/material";
 import GroupIcon from "@mui/icons-material/Group";
+import ReportProblemIcon from '@mui/icons-material/ReportProblem';
 
-export default function NoTeamsCard(props) {
+export default function NoDataCard(props) {
   return (
     <Container>
       <Stack spacing={2} alignItems="center">
-        <GroupIcon sx={{ fontSize: 60, color: "text.secondary" }} />
+        <ReportProblemIcon sx={{ fontSize: 60, color: "text.secondary" }} />
         <Typography variant="body1" color="text.secondary" align="center">
-          No teams to show. Join or create a team to see team information.
+          {props.text}
         </Typography>
       </Stack>
     </Container>

--- a/src/frontend/src/components/RosterTable.jsx
+++ b/src/frontend/src/components/RosterTable.jsx
@@ -20,12 +20,16 @@ export default function RosterTable(props) {
           </TableRow>
         </TableHead>
         <TableBody>
-          {props.players.map((player, index) => (
+          {props.roster.map((player, index) => (
             <TableRow key={index}>
-              {props.players.captain === player.name ? (
-                <TableCell>{player.name} (Captain) </TableCell>
+              {props.captain.id === player.id ? (
+                <TableCell>
+                  {player.firstName} {player.lastName} (Captain){" "}
+                </TableCell>
               ) : (
-                <TableCell>{player.name}</TableCell>
+                <TableCell>
+                  {player.firstName} {player.lastName}
+                </TableCell>
               )}
               <TableCell>{player.email}</TableCell>
             </TableRow>

--- a/src/frontend/src/routes.js
+++ b/src/frontend/src/routes.js
@@ -15,7 +15,7 @@ import SchedulePage from "./views/SchedulePage";
 const routes = [
   { path: "/home", component: HomePage },
   { path: "/", component: LoginPage },
-  { path: "/team", component: MyTeamPage },
+  { path: "/team/:id", component: MyTeamPage },
   { path: "/standings", component: StandingsPage },
   { path: "/manage", component: LeagueManagementPage, private: true },
   { path: "/announcements", component: AnnouncementsPage },

--- a/src/frontend/src/routes.js
+++ b/src/frontend/src/routes.js
@@ -15,6 +15,7 @@ import SchedulePage from "./views/SchedulePage";
 const routes = [
   { path: "/home", component: HomePage },
   { path: "/", component: LoginPage },
+  { path: "/team/", component: MyTeamPage },
   { path: "/team/:id", component: MyTeamPage },
   { path: "/standings", component: StandingsPage },
   { path: "/manage", component: LeagueManagementPage, private: true },


### PR DESCRIPTION
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/9d396c80-71a2-4a62-82a7-715b78e004a1" />

Changes:
- the team record, name, division is displayed from the true data.
- the `/team` url now goes to `/team/:id`. Its currently set to the player's team id, but we need the team id in the backend to actually be an array - and then the default teamId can just be `teams[0].id`. When this is done, we can display a TAB for each team, and on tab change, the url id is updated to the team that is being viewed

Started to connect the my team page to the backend.  Some blockers from completing this fully:

- team probably needs a "schedule" key. at minimum the season needs a scheduleId key. otherwise theres no good way to get the player's schedule from its object (@JadHay8 , maybe you could help update the schedule backend?)
- I stlil would need to only display notifications if it is the captain view


