### PR TITLE
Changing Schedule Algo to Round Robin + fixing bugs

### DIFF
--- a/src/backend/controllers/players-controllers.js
+++ b/src/backend/controllers/players-controllers.js
@@ -10,7 +10,10 @@ const getPlayers = async (req, res, next) => {
   try {
     players = await Player.find(); // todo: remove password for privacy
   } catch (err) {
-    const error = new HttpError("Fetching players failed, please try again later.", 500);
+    const error = new HttpError(
+      "Fetching players failed, please try again later.",
+      500
+    );
     return next(error);
   }
   res.json({
@@ -21,7 +24,9 @@ const getPlayers = async (req, res, next) => {
 const signup = async (req, res, next) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
-    return next(new HttpError("Invalid inputs passed, please check your data.", 422));
+    return next(
+      new HttpError("Invalid inputs passed, please check your data.", 422)
+    );
   }
   const { firstName, lastName, email, password, role } = req.body;
 
@@ -29,12 +34,18 @@ const signup = async (req, res, next) => {
   try {
     existingPlayer = await Player.findOne({ email: email });
   } catch (err) {
-    const error = new HttpError("Signing up failed, please try again later.", 500);
+    const error = new HttpError(
+      "Signing up failed, please try again later.",
+      500
+    );
     return next(error);
   }
 
   if (existingPlayer) {
-    const error = new HttpError("Player exists already, please login instead.", 422);
+    const error = new HttpError(
+      "Player exists already, please login instead.",
+      422
+    );
     return next(error);
   }
 
@@ -42,7 +53,10 @@ const signup = async (req, res, next) => {
   try {
     hashedPassword = await bcrypt.hash(password, 12);
   } catch (err) {
-    const error = new HttpError("Could not create player, please try again.", 500);
+    const error = new HttpError(
+      "Could not create player, please try again.",
+      500
+    );
     return next(error);
   }
 
@@ -65,9 +79,16 @@ const signup = async (req, res, next) => {
 
   let token;
   try {
-    token = jwt.sign({ playerId: createdPlayer.id, email: createdPlayer.email }, "SECRET", { expiresIn: "2h" });
+    token = jwt.sign(
+      { playerId: createdPlayer.id, email: createdPlayer.email },
+      "SECRET",
+      { expiresIn: "2h" }
+    );
   } catch (err) {
-    const error = new HttpError("Signing up failed, please try again later.", 500);
+    const error = new HttpError(
+      "Signing up failed, please try again later.",
+      500
+    );
     return next(error);
   }
 
@@ -86,12 +107,18 @@ const login = async (req, res, next) => {
   try {
     existingPlayer = await Player.findOne({ email: email });
   } catch (err) {
-    const error = new HttpError("Logging in failed, please try again later.", 500);
+    const error = new HttpError(
+      "Logging in failed, please try again later.",
+      500
+    );
     return next(error);
   }
 
   if (!existingPlayer) {
-    const error = new HttpError("Invalid credentials, could not log you in.", 403);
+    const error = new HttpError(
+      "Invalid credentials, could not log you in.",
+      403
+    );
     return next(error);
   }
 
@@ -99,20 +126,33 @@ const login = async (req, res, next) => {
   try {
     isValidPassword = await bcrypt.compare(password, existingPlayer.password);
   } catch (err) {
-    const error = new HttpError("Could not log you in, please check your credentials and try again.", 500);
+    const error = new HttpError(
+      "Could not log you in, please check your credentials and try again.",
+      500
+    );
     return next(error);
   }
 
   if (!isValidPassword) {
-    const error = new HttpError("Invalid credentials, could not log you in.", 403);
+    const error = new HttpError(
+      "Invalid credentials, could not log you in.",
+      403
+    );
     return next(error);
   }
 
   let token;
   try {
-    token = jwt.sign({ playerId: existingPlayer.id, email: existingPlayer.email }, "SECRET", { expiresIn: "2h" });
+    token = jwt.sign(
+      { playerId: existingPlayer.id, email: existingPlayer.email },
+      "SECRET",
+      { expiresIn: "2h" }
+    );
   } catch (err) {
-    const error = new HttpError("Logging in failed, please try again later.", 500);
+    const error = new HttpError(
+      "Logging in failed, please try again later.",
+      500
+    );
     return next(error);
   }
 
@@ -128,22 +168,33 @@ const getPlayerById = async (req, res, next) => {
 
   let player;
   try {
-    player = await Player.findById(playerId).populate({
-      path: "team",
-      populate: [
-        { path: "roster" }, // Populate roster with player details
-        { path: "captainId" }, // Populate captain details
-        { path: "divisionId" }, // Populate division details
-        { path: "seasonId" }, // Populate season details
-      ],
-    });
+    player = await Player.findById(playerId)
+      .populate({
+        path: "team",
+        populate: [
+          { path: "roster" }, // Populate roster with player details
+          { path: "captainId" }, // Populate captain details
+          { path: "divisionId" }, // Populate division details
+          { path: "seasonId" }, // Populate season details
+        ],
+      })
+      .populate({
+        path: "invites",
+        populate: [{ path: "divisionId" }, { path: "captainId" }],
+      });
   } catch (err) {
-    const error = new HttpError("Fetching player failed, please try again later.", 500);
+    const error = new HttpError(
+      "Fetching player failed, please try again later.",
+      500
+    );
     return next(error);
   }
 
   if (!player) {
-    const error = new HttpError("Could not find a player for the provided id.", 404);
+    const error = new HttpError(
+      "Could not find a player for the provided id.",
+      404
+    );
     return next(error);
   }
 
@@ -160,14 +211,20 @@ const acceptInvite = async (req, res, next) => {
     // Find the player by ID
     player = await Player.findById(playerId);
     if (!player) {
-      const error = new HttpError("Could not find a player for the provided id.", 404);
+      const error = new HttpError(
+        "Could not find a player for the provided id.",
+        404
+      );
       return next(error);
     }
 
     // Find the team by ID
     team = await Team.findById(teamId); // Assuming you have a Team model
     if (!team) {
-      const error = new HttpError("Could not find the team for the provided id.", 404);
+      const error = new HttpError(
+        "Could not find the team for the provided id.",
+        404
+      );
       return next(error);
     }
 
@@ -181,7 +238,10 @@ const acceptInvite = async (req, res, next) => {
     team.roster.push(player._id);
     await team.save();
   } catch (err) {
-    const error = new HttpError("Accepting the invite failed, please try again later.", 500);
+    const error = new HttpError(
+      "Accepting the invite failed, please try again later.",
+      500
+    );
     return next(error);
   }
 
@@ -200,7 +260,10 @@ const sendInvite = async (req, res, next) => {
     // Find the player by ID
     player = await Player.findById(playerId);
     if (!player) {
-      const error = new HttpError("Could not find a player for the provided id.", 404);
+      const error = new HttpError(
+        "Could not find a player for the provided id.",
+        404
+      );
       return next(error);
     }
 
@@ -213,14 +276,20 @@ const sendInvite = async (req, res, next) => {
     // Find the team by ID
     team = await Team.findById(teamId);
     if (!team) {
-      const error = new HttpError("Could not find the team for the provided id.", 404);
+      const error = new HttpError(
+        "Could not find the team for the provided id.",
+        404
+      );
       return next(error);
     }
 
     player.invites.push(team._id); // Add the team ID to the player's invites array
     await player.save(); // Save the player document
   } catch (err) {
-    const error = new HttpError("Inviting the player failed, please try again later.", 500);
+    const error = new HttpError(
+      "Inviting the player failed, please try again later.",
+      500
+    );
     return next(error);
   }
 

--- a/src/frontend/src/components/NotificationsRow.jsx
+++ b/src/frontend/src/components/NotificationsRow.jsx
@@ -3,17 +3,43 @@ import { Box, Card, CardContent, Typography } from "@mui/material";
 
 export default function NotificationsRow(props) {
   return (
-    <Box sx={{ display: "flex", gap: 2, mb: 6, overflowX: "auto" }}>
-      {props.notifications.map((notification, index) => (
-        <Card key={index} sx={{ minWidth: 300 }}>
-          <CardContent>
-            <Typography variant="h6" gutterBottom>
-              {notification.title}
-            </Typography>
-            <Typography variant="body2">{notification.description}</Typography>
-          </CardContent>
-        </Card>
-      ))}
+    <Box sx={{ display: "flex", gap: 2, overflowX: "auto" }}>
+      {props.notifications &&
+        props.notifications.map((notification, index) => (
+          <Card key={index} sx={{ minWidth: 300 }}>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                {notification.title}
+              </Typography>
+              <Typography variant="body2">
+                {notification.description}
+              </Typography>
+            </CardContent>
+          </Card>
+        ))}
+      {props.teamInvites &&
+        props.teamInvites.map((teamInvite, index) => (
+          <Card key={index} sx={{ width: 300, wordWrap: "break-word" }}>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Invite from {teamInvite.name}
+              </Typography>
+              <Typography
+                variant="body2"
+                sx={{
+                  wordWrap: "break-word",
+                  overflowWrap: "break-word",
+                  whiteSpace: "normal",
+                }}
+              >
+                You have been invited by {teamInvite.captainId.firstName}{" "}
+                {teamInvite.captainId.lastName} to join {teamInvite.name} in{" "}
+                {teamInvite.divisionId.name}.
+              </Typography>
+              {/* Either need to add accept/decline functionality here or redireect to where this functionality is */}
+            </CardContent>
+          </Card>
+        ))}
     </Box>
   );
 }

--- a/src/frontend/src/components/RosterTable.jsx
+++ b/src/frontend/src/components/RosterTable.jsx
@@ -11,7 +11,7 @@ import {
 
 export default function RosterTable(props) {
   return (
-    <TableContainer component={Paper} sx={{ mb: 6 }}>
+    <TableContainer component={Paper} sx={{ mb: 2 }}>
       <Table>
         <TableHead>
           <TableRow>

--- a/src/frontend/src/components/TeamSchedulingComponent.jsx
+++ b/src/frontend/src/components/TeamSchedulingComponent.jsx
@@ -5,6 +5,7 @@ import { DivisionCard } from "./DivisionCard";
 import { launchSeason, updateSeasonDivisionTeams } from "../api/season";
 import { generateSchedule, getScheduleBySeasonId } from "../api/schedule";
 import ScheduleTable from "./ScheduleTable";
+import LoadingOverlay from "./LoadingOverlay";
 
 export default function TeamSchedulingComponent(props) {
   const [divisionsSet, setDivisionsSet] = useState(false);
@@ -54,10 +55,11 @@ export default function TeamSchedulingComponent(props) {
         setLoading(true);
         await updateSeasonDivisionTeams(seasonId, divisionTeams);
         setDivisionsSet(true);
-        setLoading(false);
       } catch (err) {
         setLoading(false);
         setError(err.message || "Failed to update division teams");
+      } finally {
+        setLoading(false);
       }
     };
 
@@ -79,7 +81,6 @@ export default function TeamSchedulingComponent(props) {
     try {
       setLoading(true);
       await generateSchedule(props.season.id);
-      setLoading(false);
     } catch (error) {
       setLoading(false);
       setError(error.message || "Failed to generate schedule");
@@ -89,10 +90,11 @@ export default function TeamSchedulingComponent(props) {
       setLoading(true);
       const data = await getScheduleBySeasonId(props.season.id);
       setSchedule(data.schedule);
-      setLoading(false);
     } catch (error) {
       setLoading(false);
       setError(error.message || "Failed to get schedule");
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -119,6 +121,7 @@ export default function TeamSchedulingComponent(props) {
 
   return (
     <>
+      {loading && <LoadingOverlay loading={loading} />}
       <Typography variant="h6" gutterBottom sx={{ mb: 2, mt: 2 }}>
         Registered Teams
       </Typography>

--- a/src/frontend/src/views/HomePage.jsx
+++ b/src/frontend/src/views/HomePage.jsx
@@ -23,6 +23,7 @@ import {
 import { getAnnouncements } from "../api/announcements";
 import { SeasonsCard } from "../components/SeasonsCard";
 import GSALogo from "../assets/GSALogo.png";
+import LoadingOverlay from "../components/LoadingOverlay";
 
 const StyledCard = styled(Card)(({ theme }) => ({
   height: "300px",
@@ -53,53 +54,40 @@ export default function HomePage() {
   useEffect(() => {
     const fetchUpcomingSeasons = async () => {
       try {
+        setLoading(true);
         const data = await getUpcomingSeasons();
         setUpcomingSeasons(data.seasons);
-        console.log("Upcoming Seasons:", data.seasons);
       } catch (err) {
         setError(err.message || "Failed to fetch upcoming seasons");
-      } finally {
-        setLoading(false);
       }
     };
 
     const fetchOngoingSeasons = async () => {
       try {
+        setLoading(true);
         const data = await getOngoingSeasons();
         setOngoingSeasons(data.seasons);
-        console.log("Ongoing Seasons:", data.seasons);
       } catch (err) {
         setError(err.message || "Failed to fetch ongoing seasons");
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    const fetchArchivedSeasons = async () => {
-      try {
-        const data = await getArchivedSeasons();
-        setArchivedSeasons(data.seasons);
-        console.log("Archived Seasons:", data.seasons);
-      } catch (err) {
-        setError(err.message || "Failed to fetch archived seasons");
-      } finally {
-        setLoading(false);
       }
     };
 
     const fetchAnnouncements = async () => {
       try {
         const data = await getAnnouncements();
-        const sortedAnnouncements = data.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+        const sortedAnnouncements = data.sort(
+          (a, b) => new Date(b.createdAt) - new Date(a.createdAt)
+        );
         setAnnouncements(sortedAnnouncements.slice(0, 3)); // Get the 3 most recent announcements
       } catch (err) {
         setError(err.message || "Failed to fetch announcements");
+      } finally {
+        setLoading(false);
       }
     };
 
     fetchUpcomingSeasons();
     fetchOngoingSeasons();
-    fetchArchivedSeasons();
     fetchAnnouncements();
   }, []);
 
@@ -107,83 +95,81 @@ export default function HomePage() {
     <>
       <NavBar />
       <Box sx={{ bgcolor: "background.default", minHeight: "100vh" }}>
-      
-      {/* Hero Section */}
-      <Container maxWidth="lg" sx={{ pt: 8, pb: 4, width: "100%" }}>
-        <Grid container spacing={2} alignItems="center">
-          {/* Title and Welcome Message */}
-          <Grid item xs={8} md={8}>
-            <Typography
-              variant="h1"
+        {loading && <LoadingOverlay loading={loading} />}
+        {/* Hero Section */}
+        <Container maxWidth="lg" sx={{ pt: 8, pb: 4, width: "100%" }}>
+          <Grid container spacing={2} alignItems="center">
+            {/* Title and Welcome Message */}
+            <Grid item xs={8} md={8}>
+              <Typography
+                variant="h1"
+                sx={{
+                  fontSize: { xs: "3rem", md: "4rem" },
+                  fontWeight: 900,
+                  color: "text.primary",
+                  mb: 1,
+                }}
+              >
+                McMaster GSA
+              </Typography>
+              <Typography
+                variant="body1"
+                sx={{ color: "text.secondary", fontSize: "1.1rem" }}
+              >
+                Welcome to the McMaster Graduate Students Association Softball
+                League!
+              </Typography>
+            </Grid>
+
+            {/* Logo */}
+            <Grid
+              item
+              xs={4}
+              md={4}
               sx={{
-                fontSize: { xs: "3rem", md: "4rem" },
-                fontWeight: 900,
-                color: "text.primary",
-                mb: 1,
+                display: "flex",
+                justifyContent: "flex-end",
+                alignItems: "center",
               }}
             >
-              McMaster GSA
-            </Typography>
-            <Typography
-              variant="body1"
-              sx={{ color: "text.secondary", fontSize: "1.1rem" }}
+              <img
+                src={GSALogo}
+                alt="GSA Logo"
+                style={{
+                  width: "300px",
+                  height: "auto",
+                  objectFit: "contain",
+                  paddingBottom: "3px",
+                }}
+              />
+            </Grid>
+          </Grid>
+        </Container>
+        {/* Seasons Section */}
+        <Container maxWidth="lg" sx={{ pt: 4, pb: 4 }}>
+          <Accordion defaultExpanded={true}>
+            <AccordionSummary
+              expandIcon={<ArrowDropDownIcon />}
+              id="upcoming-header"
             >
-              Welcome to the McMaster Graduate Students Association Softball League!
-            </Typography>
-          </Grid>
-
-          {/* Logo */}
-          <Grid
-            item
-            xs={4}
-            md={4}
-            sx={{
-              display: "flex",
-              justifyContent: "flex-end",
-              alignItems: "center",
-            }}
-          >
-            <img
-              src={GSALogo}
-              alt="GSA Logo"
-              style={{
-                width: "300px",
-                height: "auto",
-                objectFit: "contain",
-                paddingBottom: "3px",
-              }}
-            />
-          </Grid>
-        </Grid>
-      </Container>
-
-      {/* Seasons Section */}
-      <Container maxWidth="lg" sx={{ pt: 4, pb: 4 }}>
-        <Accordion defaultExpanded={true}>
-          <AccordionSummary
-            expandIcon={<ArrowDropDownIcon />}
-            id="upcoming-header"
-          >
-            <Typography component="span">Upcoming Seasons</Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <SeasonsCard seasons={upcomingSeasons} status="Upcoming" />
-          </AccordionDetails>
-        </Accordion>
-        <Accordion>
-          <AccordionSummary
-            expandIcon={<ArrowDropDownIcon />}
-            id="ongoing-header"
-          >
-            <Typography component="span">Ongoing Seasons</Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <SeasonsCard seasons={ongoingSeasons} status="Ongoing" />
-          </AccordionDetails>
-        </Accordion>
-      </Container>
-
-
+              <Typography component="span">Upcoming Seasons</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <SeasonsCard seasons={upcomingSeasons} status="Upcoming" />
+            </AccordionDetails>
+          </Accordion>
+          <Accordion>
+            <AccordionSummary
+              expandIcon={<ArrowDropDownIcon />}
+              id="ongoing-header"
+            >
+              <Typography component="span">Ongoing Seasons</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <SeasonsCard seasons={ongoingSeasons} status="Ongoing" />
+            </AccordionDetails>
+          </Accordion>
+        </Container>
         {/* Announcements Section */}
         <Box sx={{ py: 8 }}>
           <Container maxWidth="lg">
@@ -213,12 +199,13 @@ export default function HomePage() {
                 announcements.map((announcement) => (
                   <Grid item xs={12} md={4} key={announcement._id}>
                     <StyledCard>
-                      <CardContent sx={{ 
+                      <CardContent
+                        sx={{
                           flexGrow: 1,
                           display: "flex",
                           flexDirection: "column",
-                          justifyContent: "space-between"
-                          }}
+                          justifyContent: "space-between",
+                        }}
                       >
                         <Typography
                           gutterBottom
@@ -230,7 +217,11 @@ export default function HomePage() {
                         >
                           {announcement.title}
                         </Typography>
-                        <Typography variant="body" color="text.secondary" sx={{ mb: 2 }}>
+                        <Typography
+                          variant="body"
+                          color="text.secondary"
+                          sx={{ mb: 2 }}
+                        >
                           {announcement.content.length > 100
                             ? `${announcement.content.substring(0, 100)}...`
                             : announcement.content}
@@ -247,7 +238,11 @@ export default function HomePage() {
                               opacity: 0.9,
                             },
                           }}
-                          onClick={() => navigate(`/announcements`, { state: {selectedAnnouncement: announcement} })}
+                          onClick={() =>
+                            navigate(`/announcements`, {
+                              state: { selectedAnnouncement: announcement },
+                            })
+                          }
                         >
                           Read More
                         </Button>

--- a/src/frontend/src/views/HomePage.jsx
+++ b/src/frontend/src/views/HomePage.jsx
@@ -27,6 +27,7 @@ import LoadingOverlay from "../components/LoadingOverlay";
 import { getPlayerById } from "../api/player";
 import { useAuth } from "../hooks/AuthProvider";
 import NotificationsRow from "../components/NotificationsRow";
+import NoDataCard from "../components/NoDataCard";
 
 const StyledCard = styled(Card)(({ theme }) => ({
   height: "300px",
@@ -206,7 +207,11 @@ export default function HomePage() {
           >
             Invitations
           </Typography>
-          <NotificationsRow teamInvites={player && player.invites} />
+          {player && player.invites && player.invites.length === 0 ? (
+            <NoDataCard text="No invitations to show." />
+          ) : (
+            <NotificationsRow teamInvites={player && player.invites} />
+          )}
         </Container>
         {/* Announcements Section */}
         <Box sx={{ py: 2 }}>

--- a/src/frontend/src/views/HomePage.jsx
+++ b/src/frontend/src/views/HomePage.jsx
@@ -24,6 +24,9 @@ import { getAnnouncements } from "../api/announcements";
 import { SeasonsCard } from "../components/SeasonsCard";
 import GSALogo from "../assets/GSALogo.png";
 import LoadingOverlay from "../components/LoadingOverlay";
+import { getPlayerById } from "../api/player";
+import { useAuth } from "../hooks/AuthProvider";
+import NotificationsRow from "../components/NotificationsRow";
 
 const StyledCard = styled(Card)(({ theme }) => ({
   height: "300px",
@@ -42,16 +45,28 @@ const StyledCard = styled(Card)(({ theme }) => ({
 
 export default function HomePage() {
   const navigate = useNavigate();
+  const auth = useAuth();
+  const [player, setPlayer] = useState(null);
   const [upcomingSeasons, setUpcomingSeasons] = useState(null);
   const [ongoingSeasons, setOngoingSeasons] = useState(null);
   const [archivedSeasons, setArchivedSeasons] = useState(null);
   const [announcements, setAnnouncements] = useState([]); // Store fetched announcements
-
   // todo: can use these to show loading spinner or error message
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    const fetchPlayerById = async (pid) => {
+      try {
+        setLoading(true);
+        const data = await getPlayerById(pid);
+        setPlayer(data.player);
+        console.log(data.player);
+      } catch (err) {
+        setError(err.message || "Failed to fetch player");
+      }
+    };
+
     const fetchUpcomingSeasons = async () => {
       try {
         setLoading(true);
@@ -85,7 +100,7 @@ export default function HomePage() {
         setLoading(false);
       }
     };
-
+    fetchPlayerById(auth.playerId);
     fetchUpcomingSeasons();
     fetchOngoingSeasons();
     fetchAnnouncements();
@@ -145,8 +160,18 @@ export default function HomePage() {
             </Grid>
           </Grid>
         </Container>
-        {/* Seasons Section */}
-        <Container maxWidth="lg" sx={{ pt: 4, pb: 4 }}>
+        <Container maxWidth="lg" sx={{ pt: 2 }}>
+          {/* Seasons Section */}
+          <Typography
+            variant="h3"
+            sx={{
+              fontSize: { xs: "2rem", md: "3rem" },
+              fontWeight: 700,
+              mb: 2,
+            }}
+          >
+            Seasons
+          </Typography>
           <Accordion defaultExpanded={true}>
             <AccordionSummary
               expandIcon={<ArrowDropDownIcon />}
@@ -170,8 +195,21 @@ export default function HomePage() {
             </AccordionDetails>
           </Accordion>
         </Container>
+        <Container maxWidth="lg" sx={{ pt: 2 }}>
+          <Typography
+            variant="h3"
+            sx={{
+              fontSize: { xs: "2rem", md: "3rem" },
+              fontWeight: 700,
+              mt: 4,
+            }}
+          >
+            Invitations
+          </Typography>
+          <NotificationsRow teamInvites={player && player.invites} />
+        </Container>
         {/* Announcements Section */}
-        <Box sx={{ py: 8 }}>
+        <Box sx={{ py: 2 }}>
           <Container maxWidth="lg">
             <Box
               sx={{

--- a/src/frontend/src/views/LeagueManagementPage.jsx
+++ b/src/frontend/src/views/LeagueManagementPage.jsx
@@ -26,6 +26,7 @@ import { formatDate } from "../utils/Formatting";
 import CreateSeasonForm from "../components/manage/CreateSeasonForm";
 import SeasonsTable from "../components/manage/SeasonsTable";
 import ScheduleTable from "../components/ScheduleTable";
+import LoadingOverlay from "../components/LoadingOverlay";
 
 const columns = [
   { header: "Game ID", key: "game_id" },
@@ -58,12 +59,11 @@ const LeagueManagementPage = () => {
   useEffect(() => {
     const fetchUpcomingSeasons = async () => {
       try {
+        setLoading(true);
         const data = await getUpcomingSeasons();
         setUpcomingSeasons(data.seasons);
       } catch (err) {
         setError(err.message || "Failed to fetch upcoming seasons");
-      } finally {
-        setLoading(false);
       }
     };
 
@@ -73,8 +73,6 @@ const LeagueManagementPage = () => {
         setOngoingSeasons(data.seasons);
       } catch (err) {
         setError(err.message || "Failed to fetch ongoing seasons");
-      } finally {
-        setLoading(false);
       }
     };
 
@@ -97,6 +95,8 @@ const LeagueManagementPage = () => {
   return (
     <>
       <NavBar />
+      {loading && <LoadingOverlay loading={loading} />}
+
       <Container maxWidth="lg" sx={{ mt: 4 }}>
         <Typography variant="h5" gutterBottom sx={{ mb: 2 }}>
           League Management

--- a/src/frontend/src/views/MyTeamPage.jsx
+++ b/src/frontend/src/views/MyTeamPage.jsx
@@ -41,6 +41,8 @@ export default function MyTeamPage() {
         setPlayer(data.player);
       } catch (err) {
         setError(err.message || "Failed to fetch player");
+      } finally {
+        setLoading(false);
       }
     };
 

--- a/src/frontend/src/views/MyTeamPage.jsx
+++ b/src/frontend/src/views/MyTeamPage.jsx
@@ -1,4 +1,4 @@
-import { Typography, Container, Box, Tab, Stack } from "@mui/material";
+import { Typography, Container, Box, Tab, Stack, Button } from "@mui/material";
 import NavBar from "../components/NavBar";
 import RosterTable from "../components/RosterTable";
 import ScheduleTable from "../components/ScheduleTable";
@@ -138,6 +138,17 @@ export default function MyTeamPage() {
                   roster={player.team.roster}
                   captain={player.team.captainId}
                 />
+                <Button
+                  variant="contained"
+                  size="small"
+                  sx={{
+                    bgcolor: "#800020",
+                    mb: 2,
+                  }}
+                  onClick={() => navigate("/players")}
+                >
+                  Invite Players
+                </Button>
 
                 <Typography variant="h4" component="h2" gutterBottom>
                   Upcoming Games

--- a/src/frontend/src/views/PlayersPage.jsx
+++ b/src/frontend/src/views/PlayersPage.jsx
@@ -3,27 +3,38 @@ import NavBar from "../components/NavBar";
 import PlayerTable from "../components/PlayerTable";
 import { allPlayers } from "../api/player";
 import { useState, useEffect } from "react";
+import LoadingOverlay from "../components/LoadingOverlay";
 
 export default function Players() {
-    const [players, setPlayers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [players, setPlayers] = useState([]);
 
-    useEffect(() => {
-        allPlayers()
-            .then((data) => {
-                setPlayers(data.players);
-            })
-            .catch((error) => console.error("Error fetching players:", error.message));
-    }, []);
+  useEffect(() => {
+    const fetchPlayers = async () => {
+      try {
+        setLoading(true);
+        const data = await allPlayers();
+        setPlayers(data.players);
+      } catch (err) {
+        console.log(err.message || "Error fetching players:");
+      } finally {
+        setLoading(false);
+      }
+    };
 
-    return (
-        <div className="min-h-screen bg-gray-50">
-            <NavBar />
-            <Container maxWidth="lg" sx={{ py: 4 }}>
-            <Typography variant="h5" component="h2" gutterBottom>
-            Players
-            </Typography>
-            <PlayerTable players={players}/>
-            </Container>
-        </div>
-    )
+    fetchPlayers();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <NavBar />
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        <LoadingOverlay loading={loading} />
+        <Typography variant="h5" component="h2" gutterBottom>
+          Players
+        </Typography>
+        <PlayerTable players={players} />
+      </Container>
+    </div>
+  );
 }

--- a/src/frontend/src/views/ProfilePage.jsx
+++ b/src/frontend/src/views/ProfilePage.jsx
@@ -1,6 +1,5 @@
-import React, { useState, useEffect } from "react"
-import NavBar from "../components/NavBar"
-import temp_team_info from "../data/team.json";
+import React, { useState, useEffect } from "react";
+import NavBar from "../components/NavBar";
 import { getPlayerById } from "../api/player";
 import { useAuth } from "../hooks/AuthProvider";
 import { acceptInvite } from "../api/player";
@@ -14,13 +13,12 @@ import {
   Avatar,
   List,
   ListItem,
-  ListItemButton,
   ListItemText,
   ListItemAvatar,
   Button,
-} from "@mui/material"
-import { styled } from "@mui/material/styles"
-import EditIcon from "@mui/icons-material/Edit"
+} from "@mui/material";
+import { styled } from "@mui/material/styles";
+import EditIcon from "@mui/icons-material/Edit";
 
 const ProfileContainer = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.common.white,
@@ -28,7 +26,7 @@ const ProfileContainer = styled(Box)(({ theme }) => ({
   padding: theme.spacing(4),
   marginTop: theme.spacing(4),
   marginBottom: theme.spacing(4),
-}))
+}));
 
 export default function ProfilePage() {
   const auth = useAuth();
@@ -43,8 +41,8 @@ export default function ProfilePage() {
     email: "",
     username: "",
     team: { id: "", name: "" }, // team object with id and name
-    invites: [] // Safe access
-  })
+    invites: [], // Safe access
+  });
 
   useEffect(() => {
     const fetchPlayerById = async (pid) => {
@@ -59,35 +57,37 @@ export default function ProfilePage() {
   }, [auth.playerId]);
 
   // track edit mode with boolean
-  const [editMode, setEditMode] = useState(false)
+  const [editMode, setEditMode] = useState(false);
 
   const handleEditClick = () => {
     // TODO: Possibly open a dialog or switch text fields from read-only to editable
     // Toggle edit mode
-    console.log("Edit button clicked")
-    setEditMode((prev) => !prev)
-  }
+    console.log("Edit button clicked");
+    setEditMode((prev) => !prev);
+  };
 
-   const handleAcceptInvite = (team) => {
-      const requestBody = {
-        playerId: auth.playerId,
-        teamId: team
-      };
-      try {
-        acceptInvite(requestBody);
-      } catch (err) {
-        console.log("Failed to accept team invite");
-      }
+  const handleAcceptInvite = (team) => {
+    const requestBody = {
+      playerId: auth.playerId,
+      teamId: team,
+    };
+    try {
+      acceptInvite(requestBody);
+    } catch (err) {
+      console.log("Failed to accept team invite");
     }
+  };
 
   return (
     <>
       <NavBar />
-      <Box sx={{
+      <Box
+        sx={{
           bgcolor: "grey.100",
           minHeight: "100vh",
           py: 4,
-        }}>
+        }}
+      >
         <Container maxWidth="lg">
           {/* Main container for profile */}
           <ProfileContainer>
@@ -111,14 +111,14 @@ export default function ProfilePage() {
                 </Typography>
               </Grid>
               <Grid item xs={12} sm={"auto"}>
-              {/* Button toggles between "Edit" and "Done" */}
+                {/* Button toggles between "Edit" and "Done" */}
                 <Button
-                    variant="contained"
-                    onClick={handleEditClick}
-                    startIcon={!editMode ? <EditIcon /> : null} // only show icon if editMode is false
-                    sx={{ borderRadius: 2, backgroundColor: "#7A003C"}}
-                    >
-                    {editMode ? "Done" : "Edit"}
+                  variant="contained"
+                  onClick={handleEditClick}
+                  startIcon={!editMode ? <EditIcon /> : null} // only show icon if editMode is false
+                  sx={{ borderRadius: 2, backgroundColor: "#7A003C" }}
+                >
+                  {editMode ? "Done" : "Edit"}
                 </Button>
               </Grid>
             </Grid>
@@ -138,10 +138,12 @@ export default function ProfilePage() {
                     InputProps={{ readOnly: !editMode }}
                     // Remove hover outlines when not in edit mode
                     sx={{
-                      ...( !editMode && {
-                          "& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline": {borderColor: "#ccc",},
-                          "& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline": {borderColor: "#ccc",},
-                        }),
+                      ...(!editMode && {
+                        "& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline":
+                          { borderColor: "#ccc" },
+                        "& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline":
+                          { borderColor: "#ccc" },
+                      }),
                     }}
                   />
                 </Grid>
@@ -157,14 +159,16 @@ export default function ProfilePage() {
                     InputProps={{ readOnly: !editMode }}
                     // Remove hover outlines when not in edit mode
                     sx={{
-                      ...( !editMode && {
-                          "& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline": {borderColor: "#ccc",},
-                          "& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline": {borderColor: "#ccc",},
-                        }),
+                      ...(!editMode && {
+                        "& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline":
+                          { borderColor: "#ccc" },
+                        "& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline":
+                          { borderColor: "#ccc" },
+                      }),
                     }}
                   />
                 </Grid>
-              
+
                 <Grid item xs={12} md={6}>
                   <Typography variant="subtitle2" sx={{ mb: 1 }}>
                     Gender
@@ -174,9 +178,11 @@ export default function ProfilePage() {
                     placeholder="Gender"
                     InputProps={{ readOnly: !editMode }}
                     sx={{
-                      ...( !editMode && {
-                        "& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline": {borderColor: "#ccc",},
-                        "& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline": {borderColor: "#ccc",},
+                      ...(!editMode && {
+                        "& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline":
+                          { borderColor: "#ccc" },
+                        "& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline":
+                          { borderColor: "#ccc" },
                       }),
                     }}
                   />
@@ -191,9 +197,11 @@ export default function ProfilePage() {
                     value={player.phoneNumber}
                     InputProps={{ readOnly: !editMode }}
                     sx={{
-                      ...( !editMode && {
-                        "& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline": {borderColor: "#ccc",},
-                        "& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline": {borderColor: "#ccc",},
+                      ...(!editMode && {
+                        "& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline":
+                          { borderColor: "#ccc" },
+                        "& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline":
+                          { borderColor: "#ccc" },
                       }),
                     }}
                   />
@@ -208,29 +216,44 @@ export default function ProfilePage() {
                   My Teams
                 </Typography>
                 <List>
-                 <ListItem>
+                  {player && player.team && (
+                    <ListItem>
                       <ListItemAvatar>
-                        <Avatar src={player.team.name} alt={player.team.name} sx={{ width: 35, height: 35, bgcolor: "#7A003C" }}>
+                        <Avatar
+                          src={player.team.name}
+                          alt={player.team.name}
+                          sx={{ width: 35, height: 35, bgcolor: "#7A003C" }}
+                        >
                           {player.team.name.charAt(0)}
                         </Avatar>
                       </ListItemAvatar>
                       <ListItemText primary={player.team.name} />
                     </ListItem>
+                  )}
                 </List>
-              </Grid> 
+              </Grid>
               <Grid item xs={12} md={6}>
                 <Typography variant="h6" sx={{ mb: 2 }}>
                   Team Invites
                 </Typography>
                 <List disablePadding>
                   {player.invites?.map((team, index) => (
-                    <ListItem key={index} secondaryAction={
-                      <>
-                        <Button color="success" onClick={() => handleAcceptInvite(team)} sx={{ mr: 1 }}>Accept</Button>
-                        {/* <Button color="error" onClick={() => handleDeclineInvite(team)}>Decline</Button> */}
-                      </>
-                    }>
-                      <ListItemText primary={team} />
+                    <ListItem
+                      key={index}
+                      secondaryAction={
+                        <>
+                          <Button
+                            color="success"
+                            onClick={() => handleAcceptInvite(team.id)}
+                            sx={{ mr: 1 }}
+                          >
+                            Accept
+                          </Button>
+                          {/* <Button color="error" onClick={() => handleDeclineInvite(team)}>Decline</Button> */}
+                        </>
+                      }
+                    >
+                      <ListItemText primary={team.name} />
                     </ListItem>
                   ))}
                 </List>
@@ -240,5 +263,5 @@ export default function ProfilePage() {
         </Container>
       </Box>
     </>
-  )
+  );
 }


### PR DESCRIPTION
Now the generateSchedule erases all existing games if it is generated again. before it was accumulating games and adding duplicates to the array. It also frees it up from the timeslots.

The **generateSchedule** uses **getDivisionMatchups** which i changed from the triple for loop killa to the round robin matchup generator. its more efficient and it is a quick fix for spreading the matchups out thoruhgout the season (instead of playing all one team first)

we'd still need to fix:
- home/away randomizing
- spread teams evenly out throughout szn
- account for team preferences
- prob more


also included small changes:
- adding button to nav to invite players from team page
- adding invites to be seen on home page (incomplete - needs accept decline or redirect)
- fixing profile page with this populated info
<img width="1197" alt="image" src="https://github.com/user-attachments/assets/ba4adfe6-a0df-414b-98ba-092cd8b07c9d" />
<img width="1292" alt="image" src="https://github.com/user-attachments/assets/c6ad8abb-6fc4-4c32-9fba-58b87f8b50df" />
