### PR TITLE
standings to include teams who have not played yet

### DIFF
--- a/src/backend/controllers/teams-controllers.js
+++ b/src/backend/controllers/teams-controllers.js
@@ -4,6 +4,7 @@ const Team = require("../models/team");
 const Season = require("../models/season");
 const Division = require("../models/division");
 const Player = require("../models/player");
+const { updateStandings } = require("./standings-controller");
 
 const getTeams = async (req, res, next) => {
   let teams;
@@ -103,7 +104,18 @@ const registerTeam = async (req, res, next) => {
   captain.team = createdTeam._id;
   await captain.save();
 
+  // STANDINGS: new team needs to be added to standings
+  try {
+    console.log("Trying updateStandings");
+    await updateStandings(createdTeam.divisionId);
+    
+  } catch (err) {
+    console.error("Error updating standings:", err);
+    return next(new HttpError("Failed to update standings", 500))
+  }
+
   res.status(201).json({ team: createdTeam });
+
 };
 
 const getTeamsById = async (req, res, next) => {

--- a/src/backend/models/standing.js
+++ b/src/backend/models/standing.js
@@ -15,9 +15,8 @@ const StandingSchema = new mongoose.Schema(
           required: true,
         },
         rank: {
-          type: Number,
-          required: true,
-          min: 1,
+          type: mongoose.Schema.Types.Mixed,
+          default: "-",
         },
         p: {
           type: Number,


### PR DESCRIPTION
previously standings were only updated upon updateScore...
put logic into registerTeams to trigger update standings as teams are registered.

To be clear if there's confusion when playing w test data --
There is a Standings obj for EACH division and within this Standings obj you have the stats for EACH Team in the division. The ENTIRE Standings obj for that division is basically recreated (this was just simpler for recalculating rankings and since there's not many teams per division I think its not too bad computationally). 
Anyway the point is standings are updated one division at a time based on 
1. registering a team to the division 
3. update a games score in the division

so if ur going through divisions in the dropdowns in standings page of old data and wondering where everything is.. nun gon change unless u do one of the above^

Teams without ranks are listed with rank "-"

![image](https://github.com/user-attachments/assets/288e304b-a80b-49f1-a7dc-a19833fe6b98)

closes #354 
