### PR TITLE
Access control for seeing notifications and submitting score

### DIFF
--- a/src/frontend/src/components/NavBar.js
+++ b/src/frontend/src/components/NavBar.js
@@ -1,5 +1,15 @@
 import React, { useEffect, useState } from "react";
-import { AppBar, Button, Toolbar, Box, IconButton, Container, Menu, MenuItem, Typography } from "@mui/material";
+import {
+  AppBar,
+  Button,
+  Toolbar,
+  Box,
+  IconButton,
+  Container,
+  Menu,
+  MenuItem,
+  Typography,
+} from "@mui/material";
 import { Person as PersonIcon } from "@mui/icons-material";
 import { useAuth } from "../hooks/AuthProvider";
 import { useNavigate } from "react-router";
@@ -42,7 +52,10 @@ const NavBar = () => {
     navigate("/profile");
   };
   return (
-    <AppBar position="static" style={{ backgroundColor: "#7A003C", height: 92 }}>
+    <AppBar
+      position="static"
+      style={{ backgroundColor: "#7A003C", height: 92 }}
+    >
       <Container style={{ marginTop: "14px" }}>
         <Toolbar disableGutters sx={{ height: 64 }}>
           <Box sx={{ display: "flex", alignItems: "center", gap: 4 }}>
@@ -79,10 +92,17 @@ const NavBar = () => {
             <Button color="inherit" href="/documentation">
               FAQ
             </Button>
+            {player && player.role === "commissioner" && (
+              <Button color="inherit" href="/manage">
+                Manage
+              </Button>
+            )}
           </Box>
           <Box sx={{ ml: "auto" }}>
             <IconButton color="inherit" size="large" onClick={handleIconClick}>
-              <Typography sx={{ mr: 1 }}>{player ? `${player.firstName} ${player.lastName}` : ""}</Typography>
+              <Typography sx={{ mr: 1 }}>
+                {player ? `${player.firstName} ${player.lastName}` : ""}
+              </Typography>
               <PersonIcon />
             </IconButton>
             <Menu anchorEl={anchorEl} open={open} onClose={handleIconClick}>

--- a/src/frontend/src/views/MyTeamPage.jsx
+++ b/src/frontend/src/views/MyTeamPage.jsx
@@ -143,16 +143,18 @@ export default function MyTeamPage() {
                 </Stack>
 
                 {/* For captain view */}
-                <Typography variant="h4" component="h2" gutterBottom>
-                  Notifications
-                </Typography>
-                {teamNotifications &&
-                teamNotifications.length > 0 ? (
-                  <NotificationsRow
-                    notifications={teamNotifications}
-                  />
-                ) : (
-                  <NoDataCard text="No notifications to show." />
+                {(player.team.captainId.id === playerId ||
+                  player.role === "commissioner") && (
+                  <>
+                    <Typography variant="h4" component="h2" gutterBottom>
+                      Notifications
+                    </Typography>
+                    {teamNotifications && teamNotifications.length > 0 ? (
+                      <NotificationsRow notifications={teamNotifications} />
+                    ) : (
+                      <NoDataCard text="No notifications to show." />
+                    )}
+                  </>
                 )}
 
                 <Typography variant="h4" component="h2" gutterBottom>
@@ -163,17 +165,18 @@ export default function MyTeamPage() {
                   captain={player.team.captainId}
                 />
                 {player.team.captainId.id === playerId && (
-                <Button
-                  variant="contained"
-                  size="small"
-                  sx={{
-                    bgcolor: "#800020",
-                    mb: 2,
-                  }}
-                  onClick={() => navigate("/players")}
-                >
-                  Invite Players
-                </Button>)}
+                  <Button
+                    variant="contained"
+                    size="small"
+                    sx={{
+                      bgcolor: "#800020",
+                      mb: 2,
+                    }}
+                    onClick={() => navigate("/players")}
+                  >
+                    Invite Players
+                  </Button>
+                )}
 
                 <Typography variant="h4" component="h2" gutterBottom>
                   Upcoming Games
@@ -186,7 +189,7 @@ export default function MyTeamPage() {
                       .filter((game) => new Date(game.date) >= new Date()) // Only future games
                       .sort((a, b) => new Date(a.date) - new Date(b.date)) // Sort by closest date
                       .slice(0, 5)}
-                    captain={player.team.captainId.id} 
+                    captain={player.team.captainId.id}
                     player={playerId}
                   />
                 ) : (
@@ -196,7 +199,12 @@ export default function MyTeamPage() {
                   Schedule
                 </Typography>
                 {teamGames && teamGames.games && teamGames.games.length > 0 ? (
-                  <ScheduleTable schedule={teamGames} captain={player.team.captainId.id} player={playerId}/>
+                  <ScheduleTable
+                    schedule={teamGames}
+                    captain={player.team.captainId.id}
+                    player={playerId}
+                    role={player.role}
+                  />
                 ) : (
                   <NoDataCard text="No schedule to show." />
                 )}


### PR DESCRIPTION
Part of #392 

## Changes 
- Players cannot see Notifications on Team Page
- Players cannot update score in ScheduleTable (in TeamPage)
- Players will just see the inputted score or blank, non-editable
- Manage is available as a tab for commissioner account
## Captain view vs Player view
captain:
<img width="1050" alt="image" src="https://github.com/user-attachments/assets/51928619-5e3e-46bc-9c44-3a841bf911d5" />
player:
<img width="1421" alt="image" src="https://github.com/user-attachments/assets/c85e903e-31cd-4d55-a4fe-0a402f011e62" />

## Commissioner navbar
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/a861d19b-c558-4e72-b0f9-8b26be4a4c0c" />

## Still to-do for RBAC
- Announcements only for Commissioner
- Reschedule only for captains and commissioner
- probably need more perms for commissioner 
