### PR TITLE
Create script to auto update season status 

### DIFF
--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -32,7 +32,8 @@
     "express": "^4.21.2",
     "express-validator": "^7.2.1",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.9.3"
+    "mongoose": "^8.9.3",
+    "node-cron": "^3.0.3"
   },
   "devDependencies": {
     "dotenv": "^16.4.7",

--- a/src/backend/scripts/updateSeasonStatuses.js
+++ b/src/backend/scripts/updateSeasonStatuses.js
@@ -1,0 +1,37 @@
+const mongoose = require("mongoose");
+const Season = require("../models/season");
+require("dotenv").config(); // Load DB credentials from .env
+
+async function updateSeasonStatuses() {
+  try {
+    await mongoose.connect(process.env.MONGO_URI);
+
+    const now = new Date();
+
+    // Update seasons from "upcoming" to "ongoing"
+    const ongoingUpdate = await Season.updateMany(
+      { startDate: { $lte: now }, endDate: { $gte: now }, status: "upcoming" },
+      { $set: { status: "ongoing" } }
+    );
+    console.log(`Updated ${ongoingUpdate.modifiedCount} seasons to 'ongoing'.`);
+
+    // Archive seasons that have ended
+    const archiveUpdate = await Season.updateMany(
+      { endDate: { $lt: now }, status: "ongoing" },
+      { $set: { status: "archived" } }
+    );
+    console.log(`Archived ${archiveUpdate.modifiedCount} seasons.`);
+
+    mongoose.connection.close();
+  } catch (error) {
+    console.error("Error updating seasons:", error);
+    mongoose.connection.close();
+  }
+}
+
+// Run script if executed directly
+if (require.main === module) {
+  updateSeasonStatuses();
+}
+
+module.exports = updateSeasonStatuses;

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -19,6 +19,15 @@ const HttpError = require("./models/http-error");
 
 const app = express();
 
+const cron = require("node-cron");
+const updateSeasonStatuses = require("./scripts/updateSeasonStatuses");
+
+// Run every day at midnight
+cron.schedule("0 0 * * *", () => {
+  console.log("Running season update job...");
+  updateSeasonStatuses();
+});
+
 // Enable CORS for all origins
 app.use(cors());
 


### PR DESCRIPTION
## Changes
- added job to auto run at midnight to update seasons status 
  - from upcoming to ongoing if the start date passed (and the commish hasnt manually started it) 
  - from ongoing to archived if the end date passed (and the commish hasnt manually ended it) 
- involves `npm install node-cron` for auto sched jobs

can manually test the script by using 
`node scripts/updateSeasonStatuses.js` in the backend directory



part of #391
