### PR TITLE
Update team record in DB on score update

### DIFF
--- a/src/backend/controllers/standings-controller.js
+++ b/src/backend/controllers/standings-controller.js
@@ -89,7 +89,20 @@ const updateStandings = async (divisionId) => {
     }    
 
   });
-  
+
+  // Update each team's record in the database
+  const updatePromises = Object.values(teamStats).map(stats => 
+    Team.findByIdAndUpdate(stats.team, {
+      $set: {
+        wins: stats.w,
+        draws: stats.d,
+        losses: stats.l
+      }
+    })
+  );
+
+  // Wait for all updates to complete
+  await Promise.all(updatePromises);
 
   // RANKING LOGIC
 


### PR DESCRIPTION
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/8fb42da9-182a-44ad-852d-ee239b79ff09" />


This record was not updated when the standings / score is updated. now it is connected and updated upon entering a score (tested in myteam page)