### PR TITLE
Team aesthetic changes

### DIFF
--- a/src/frontend/src/components/AnnouncementForm.jsx
+++ b/src/frontend/src/components/AnnouncementForm.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from "react";
 import { TextField, Button, Box, Typography } from "@mui/material";
 
-// McMaster colors
-const MCMASTER_COLORS = {
+// McMaster colours - AI Generated
+const MCMASTER_COLOURS = {
   maroon: '#7A003C',
   grey: '#5E6A71',
   gold: '#FDBF57',
@@ -43,7 +43,7 @@ export default function AnnouncementForm({ onSubmit, onDelete, initialTitle = ""
           left: 0,
           right: 0,
           height: '4px',
-          background: `linear-gradient(to right, ${MCMASTER_COLORS.maroon}, ${MCMASTER_COLORS.gold})`,
+          background: `linear-gradient(to right, ${MCMASTER_COLOURS.maroon}, ${MCMASTER_COLOURS.gold})`,
           borderRadius: '2px 2px 0 0'
         }
       }}
@@ -52,7 +52,7 @@ export default function AnnouncementForm({ onSubmit, onDelete, initialTitle = ""
         variant="h6" 
         sx={{ 
           mb: 3, 
-          color: MCMASTER_COLORS.grey,
+          color: MCMASTER_COLOURS.grey,
           fontWeight: 500
         }}
       >
@@ -69,14 +69,14 @@ export default function AnnouncementForm({ onSubmit, onDelete, initialTitle = ""
           mb: 4,
           '& .MuiOutlinedInput-root': {
             '&:hover fieldset': {
-              borderColor: MCMASTER_COLORS.maroon,
+              borderColor: MCMASTER_COLOURS.maroon,
             },
             '&.Mui-focused fieldset': {
-              borderColor: MCMASTER_COLORS.maroon,
+              borderColor: MCMASTER_COLOURS.maroon,
             },
           },
           '& .MuiInputLabel-root.Mui-focused': {
-            color: MCMASTER_COLORS.maroon,
+            color: MCMASTER_COLOURS.maroon,
           }
         }}
       />
@@ -93,14 +93,14 @@ export default function AnnouncementForm({ onSubmit, onDelete, initialTitle = ""
           mb: 4,
           '& .MuiOutlinedInput-root': {
             '&:hover fieldset': {
-              borderColor: MCMASTER_COLORS.maroon,
+              borderColor: MCMASTER_COLOURS.maroon,
             },
             '&.Mui-focused fieldset': {
-              borderColor: MCMASTER_COLORS.maroon,
+              borderColor: MCMASTER_COLOURS.maroon,
             },
           },
           '& .MuiInputLabel-root.Mui-focused': {
-            color: MCMASTER_COLORS.maroon,
+            color: MCMASTER_COLOURS.maroon,
           }
         }}
       />
@@ -110,7 +110,7 @@ export default function AnnouncementForm({ onSubmit, onDelete, initialTitle = ""
           display: "flex", 
           justifyContent: "space-between", 
           gap: 2,
-          borderTop: `1px solid ${MCMASTER_COLORS.lightGrey}`,
+          borderTop: `1px solid ${MCMASTER_COLOURS.lightGrey}`,
           pt: 3
         }}
       >
@@ -141,11 +141,11 @@ export default function AnnouncementForm({ onSubmit, onDelete, initialTitle = ""
             size="large"
             onClick={() => window.history.back()}
             sx={{
-              borderColor: MCMASTER_COLORS.grey,
-              color: MCMASTER_COLORS.grey,
+              borderColor: MCMASTER_COLOURS.grey,
+              color: MCMASTER_COLOURS.grey,
               '&:hover': {
-                borderColor: MCMASTER_COLORS.maroon,
-                color: MCMASTER_COLORS.maroon,
+                borderColor: MCMASTER_COLOURS.maroon,
+                color: MCMASTER_COLOURS.maroon,
                 bgcolor: 'transparent'
               },
               px: 3
@@ -158,7 +158,7 @@ export default function AnnouncementForm({ onSubmit, onDelete, initialTitle = ""
             variant="contained" 
             size="large"
             sx={{
-              bgcolor: MCMASTER_COLORS.maroon,
+              bgcolor: MCMASTER_COLOURS.maroon,
               '&:hover': {
                 bgcolor: '#5A002C'
               },

--- a/src/frontend/src/components/AnnouncementForm.jsx
+++ b/src/frontend/src/components/AnnouncementForm.jsx
@@ -43,6 +43,7 @@ export default function AnnouncementForm({ onSubmit, onDelete, initialTitle = ""
           left: 0,
           right: 0,
           height: '4px',
+          // AI Generated - Ombre bar styling and gradient effects
           background: `linear-gradient(to right, ${MCMASTER_COLOURS.maroon}, ${MCMASTER_COLOURS.gold})`,
           borderRadius: '2px 2px 0 0'
         }

--- a/src/frontend/src/components/AnnouncementForm.jsx
+++ b/src/frontend/src/components/AnnouncementForm.jsx
@@ -1,5 +1,13 @@
 import React, { useState, useEffect } from "react";
-import { TextField, Button, Box } from "@mui/material";
+import { TextField, Button, Box, Typography } from "@mui/material";
+
+// McMaster colors
+const MCMASTER_COLORS = {
+  maroon: '#7A003C',
+  grey: '#5E6A71',
+  gold: '#FDBF57',
+  lightGrey: '#F5F5F5',
+};
 
 export default function AnnouncementForm({ onSubmit, onDelete, initialTitle = "", initialContent = "", isEdit = false }) {
   const [title, setTitle] = useState(initialTitle);
@@ -22,62 +30,141 @@ export default function AnnouncementForm({ onSubmit, onDelete, initialTitle = ""
       onSubmit={handleSubmit}
       sx={{
         width: "100%",
-        maxWidth: "800px",
-        bgcolor: "background.paper",
-        p: 4,
+        maxWidth: "850px",
+        bgcolor: 'white',
+        p: { xs: 3, md: 6 },
         borderRadius: 2,
-        boxShadow: 3,
+        boxShadow: '0 4px 20px rgba(0,0,0,0.08)',
+        position: 'relative',
+        '&::before': {
+          content: '""',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: '4px',
+          background: `linear-gradient(to right, ${MCMASTER_COLORS.maroon}, ${MCMASTER_COLORS.gold})`,
+          borderRadius: '2px 2px 0 0'
+        }
       }}
     >
+      <Typography 
+        variant="h6" 
+        sx={{ 
+          mb: 3, 
+          color: MCMASTER_COLORS.grey,
+          fontWeight: 500
+        }}
+      >
+        {isEdit ? "Update your announcement details below" : "Share important information with your teams"}
+      </Typography>
+
       <TextField
         label="Title"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
         fullWidth
-        margin="normal"
         required
-        sx={{ mb: 3 }}
+        sx={{
+          mb: 4,
+          '& .MuiOutlinedInput-root': {
+            '&:hover fieldset': {
+              borderColor: MCMASTER_COLORS.maroon,
+            },
+            '&.Mui-focused fieldset': {
+              borderColor: MCMASTER_COLORS.maroon,
+            },
+          },
+          '& .MuiInputLabel-root.Mui-focused': {
+            color: MCMASTER_COLORS.maroon,
+          }
+        }}
       />
+
       <TextField
         label="Content"
         value={content}
         onChange={(e) => setContent(e.target.value)}
         fullWidth
-        margin="normal"
-        multiline
-        rows={6}
         required
-        sx={{ mb: 3 }}
+        multiline
+        rows={8}
+        sx={{
+          mb: 4,
+          '& .MuiOutlinedInput-root': {
+            '&:hover fieldset': {
+              borderColor: MCMASTER_COLORS.maroon,
+            },
+            '&.Mui-focused fieldset': {
+              borderColor: MCMASTER_COLORS.maroon,
+            },
+          },
+          '& .MuiInputLabel-root.Mui-focused': {
+            color: MCMASTER_COLORS.maroon,
+          }
+        }}
       />
-      <Box sx={{ display: "flex", justifyContent: "space-between", gap: 2 }}>
+
+      <Box 
+        sx={{ 
+          display: "flex", 
+          justifyContent: "space-between", 
+          gap: 2,
+          borderTop: `1px solid ${MCMASTER_COLORS.lightGrey}`,
+          pt: 3
+        }}
+      >
         {/* Delete Button */}
         {isEdit && (
           <Button
             variant="outlined"
             size="large"
-            color="error"
             onClick={onDelete}
             sx={{
-              textTransform: "none",
-              borderColor: "red",
-              color: "red",
-              "&:hover": { bgcolor: "rgba(255,0,0,0.1)" },
+              borderColor: '#d32f2f',
+              color: '#d32f2f',
+              '&:hover': {
+                backgroundColor: 'rgba(211, 47, 47, 0.04)',
+                borderColor: '#b71c1c'
+              },
+              px: 3
             }}
           >
             Delete
           </Button>
         )}
+
         {/* Cancel and Submit Buttons */}
-        <Box sx={{ display: "flex", gap: 2 }}>
+        <Box sx={{ display: "flex", gap: 2, ml: 'auto' }}>
           <Button
             variant="outlined"
             size="large"
-            sx={{ textTransform: "none" }}
             onClick={() => window.history.back()}
+            sx={{
+              borderColor: MCMASTER_COLORS.grey,
+              color: MCMASTER_COLORS.grey,
+              '&:hover': {
+                borderColor: MCMASTER_COLORS.maroon,
+                color: MCMASTER_COLORS.maroon,
+                bgcolor: 'transparent'
+              },
+              px: 3
+            }}
           >
             Cancel
           </Button>
-          <Button type="submit" variant="contained" size="large" sx={{ textTransform: "none" }}>
+          <Button 
+            type="submit" 
+            variant="contained" 
+            size="large"
+            sx={{
+              bgcolor: MCMASTER_COLORS.maroon,
+              '&:hover': {
+                bgcolor: '#5A002C'
+              },
+              px: 3
+            }}
+          >
             {isEdit ? "Save Changes" : "Create Announcement"}
           </Button>
         </Box>

--- a/src/frontend/src/components/ContactInfoTable.jsx
+++ b/src/frontend/src/components/ContactInfoTable.jsx
@@ -226,12 +226,12 @@ export default function ContactInfoTable({ currentSeasonId, allSeasons }) {
       >
         <Table>
           <TableHead>
-            <TableRow sx={{ backgroundColor: MCMASTER_COLOURS.lightGrey }}>
-              <TableCell><strong>Team Name</strong></TableCell>
-              <TableCell><strong>Division</strong></TableCell>
-              <TableCell><strong>Captain Name</strong></TableCell>
-              <TableCell><strong>Captain Email</strong></TableCell>
-              <TableCell><strong>Captain Phone</strong></TableCell>
+            <TableRow sx={{ backgroundColor: MCMASTER_COLOURS.maroon}}>
+              <TableCell sx={{ color: 'white' }}><strong>Team Name</strong></TableCell>
+              <TableCell sx={{ color: 'white' }}><strong>Division</strong></TableCell>
+              <TableCell sx={{ color: 'white' }}><strong>Captain Name</strong></TableCell>
+              <TableCell sx={{ color: 'white' }}><strong>Captain Email</strong></TableCell>
+              <TableCell sx={{ color: 'white' }}><strong>Captain Phone</strong></TableCell>
             </TableRow>
           </TableHead>
           <TableBody>

--- a/src/frontend/src/components/ContactInfoTable.jsx
+++ b/src/frontend/src/components/ContactInfoTable.jsx
@@ -16,12 +16,22 @@ import {
 } from "@mui/material";
 import { getTeams } from "../api/team";
 
-export default function ContactInfoTable({ currentSeasonId }) {
+// McMaster colors
+const MCMASTER_COLORS = {
+  maroon: '#7A003C',
+  grey: '#5E6A71',
+  gold: '#FDBF57',
+  lightGrey: '#F5F5F5',
+};
+
+export default function ContactInfoTable({ currentSeasonId, allSeasons }) {
   const [teams, setTeams] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [selectedDivision, setSelectedDivision] = useState('all');
   const [divisions, setDivisions] = useState([]);
+  const [seasons, setSeasons] = useState([]);
+  const [selectedSeason, setSelectedSeason] = useState(currentSeasonId);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -63,19 +73,59 @@ export default function ContactInfoTable({ currentSeasonId }) {
   }, [currentSeasonId]);
 
   if (loading) {
-    return <Typography>Loading Contact Info...</Typography>;
+    return (
+      <Box sx={{ 
+        minHeight: '1000px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: MCMASTER_COLORS.lightGrey
+      }}>
+        <Typography>Loading Contact Info...</Typography>
+      </Box>
+    );
   }
 
   if (error) {
-    return <Typography color="error">Error: {error}</Typography>;
+    return (
+      <Box sx={{ 
+        minHeight: '1000px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: MCMASTER_COLORS.lightGrey
+      }}>
+        <Typography color="error">Error: {error}</Typography>
+      </Box>
+    );
   }
 
   if (!currentSeasonId) {
-    return <Typography>Loading season information...</Typography>;
+    return (
+      <Box sx={{ 
+        minHeight: '1000px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: MCMASTER_COLORS.lightGrey
+      }}>
+        <Typography>Loading season information...</Typography>
+      </Box>
+    );
   }
 
   if (!teams || teams.length === 0) {
-    return <Typography>No team contact info available for the current season.</Typography>;
+    return (
+      <Box sx={{ 
+        minHeight: '1000px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: MCMASTER_COLORS.lightGrey
+      }}>
+        <Typography>No team contact info available for the current season.</Typography>
+      </Box>
+    );
   }
 
   const filteredTeams = selectedDivision === 'all' 
@@ -84,21 +134,45 @@ export default function ContactInfoTable({ currentSeasonId }) {
 
   return (
     <Box>
-      <FormControl sx={{ mb: 2, minWidth: 200 }}>
-        <InputLabel>Division</InputLabel>
-        <Select
-          value={selectedDivision}
-          label="Division"
-          onChange={(e) => setSelectedDivision(e.target.value)}
-        >
-          <MenuItem value="all">All Divisions</MenuItem>
-          {divisions.map((division) => (
-            <MenuItem key={division} value={division}>
-              {division}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
+      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+        {/* Season Dropdown */}
+        {allSeasons && (
+          <FormControl sx={{ minWidth: 200 }}>
+            <InputLabel id="season-select-label">Season</InputLabel>
+            <Select
+              labelId="season-select-label"
+              label="Season"
+              value={selectedSeason}
+              onChange={(e) => setSelectedSeason(e.target.value)}
+              sx={{ bgcolor: 'white' }}
+            >
+              {seasons.map((season) => (
+                <MenuItem key={season._id} value={season._id}>
+                  {season.name} {season.status === "archived" ? " (Archived)" : ""}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
+
+        {/* Division Dropdown */}
+        <FormControl sx={{ minWidth: 200 }}>
+          <InputLabel>Division</InputLabel>
+          <Select
+            value={selectedDivision}
+            label="Division"
+            onChange={(e) => setSelectedDivision(e.target.value)}
+            sx={{ bgcolor: 'white' }}
+          >
+            <MenuItem value="all">All Divisions</MenuItem>
+            {divisions.map((division) => (
+              <MenuItem key={division} value={division}>
+                {division}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
 
       <TableContainer component={Paper}>
         <Table>

--- a/src/frontend/src/components/ContactInfoTable.jsx
+++ b/src/frontend/src/components/ContactInfoTable.jsx
@@ -16,8 +16,8 @@ import {
 } from "@mui/material";
 import { getTeams, getSeasons } from "../api/team";
 
-// McMaster colors
-const MCMASTER_COLORS = {
+// McMaster colours - AI Generated
+const MCMASTER_COLOURS = {
   maroon: '#7A003C',
   grey: '#5E6A71',
   gold: '#FDBF57',
@@ -95,7 +95,7 @@ export default function ContactInfoTable({ currentSeasonId, allSeasons }) {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        backgroundColor: MCMASTER_COLORS.lightGrey
+        backgroundColor: MCMASTER_COLOURS.lightGrey
       }}>
         <Typography>Loading Contact Info...</Typography>
       </Box>
@@ -109,7 +109,7 @@ export default function ContactInfoTable({ currentSeasonId, allSeasons }) {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        backgroundColor: MCMASTER_COLORS.lightGrey
+        backgroundColor: MCMASTER_COLOURS.lightGrey
       }}>
         <Typography color="error">Error: {error}</Typography>
       </Box>
@@ -123,7 +123,7 @@ export default function ContactInfoTable({ currentSeasonId, allSeasons }) {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        backgroundColor: MCMASTER_COLORS.lightGrey
+        backgroundColor: MCMASTER_COLOURS.lightGrey
       }}>
         <Typography>Loading season information...</Typography>
       </Box>
@@ -137,7 +137,7 @@ export default function ContactInfoTable({ currentSeasonId, allSeasons }) {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        backgroundColor: MCMASTER_COLORS.lightGrey
+        backgroundColor: MCMASTER_COLOURS.lightGrey
       }}>
         <Typography>No team contact info available for the current season.</Typography>
       </Box>
@@ -157,14 +157,14 @@ export default function ContactInfoTable({ currentSeasonId, allSeasons }) {
             minWidth: 220,
             '& .MuiOutlinedInput-root': {
               '&:hover fieldset': {
-                borderColor: MCMASTER_COLORS.maroon,
+                borderColor: MCMASTER_COLOURS.maroon,
               },
               '&.Mui-focused fieldset': {
-                borderColor: MCMASTER_COLORS.maroon,
+                borderColor: MCMASTER_COLOURS.maroon,
               }
             },
             '& .MuiInputLabel-root.Mui-focused': {
-              color: MCMASTER_COLORS.maroon,
+              color: MCMASTER_COLOURS.maroon,
             }
           }}
         >
@@ -181,13 +181,13 @@ export default function ContactInfoTable({ currentSeasonId, allSeasons }) {
               value="all"
               sx={{
                 '&.Mui-selected': {
-                  backgroundColor: `${MCMASTER_COLORS.maroon}14`,
+                  backgroundColor: `${MCMASTER_COLOURS.maroon}14`,
                   '&:hover': {
-                    backgroundColor: `${MCMASTER_COLORS.maroon}20`,
+                    backgroundColor: `${MCMASTER_COLOURS.maroon}20`,
                   }
                 },
                 '&:hover': {
-                  backgroundColor: `${MCMASTER_COLORS.maroon}0A`,
+                  backgroundColor: `${MCMASTER_COLOURS.maroon}0A`,
                 }
               }}
             >
@@ -199,13 +199,13 @@ export default function ContactInfoTable({ currentSeasonId, allSeasons }) {
                 value={division}
                 sx={{
                   '&.Mui-selected': {
-                    backgroundColor: `${MCMASTER_COLORS.maroon}14`,
+                    backgroundColor: `${MCMASTER_COLOURS.maroon}14`,
                     '&:hover': {
-                      backgroundColor: `${MCMASTER_COLORS.maroon}20`,
+                      backgroundColor: `${MCMASTER_COLOURS.maroon}20`,
                     }
                   },
                   '&:hover': {
-                    backgroundColor: `${MCMASTER_COLORS.maroon}0A`,
+                    backgroundColor: `${MCMASTER_COLOURS.maroon}0A`,
                   }
                 }}
               >
@@ -226,7 +226,7 @@ export default function ContactInfoTable({ currentSeasonId, allSeasons }) {
       >
         <Table>
           <TableHead>
-            <TableRow sx={{ backgroundColor: MCMASTER_COLORS.lightGrey }}>
+            <TableRow sx={{ backgroundColor: MCMASTER_COLOURS.lightGrey }}>
               <TableCell><strong>Team Name</strong></TableCell>
               <TableCell><strong>Division</strong></TableCell>
               <TableCell><strong>Captain Name</strong></TableCell>

--- a/src/frontend/src/components/ContactInfoTable.jsx
+++ b/src/frontend/src/components/ContactInfoTable.jsx
@@ -150,37 +150,65 @@ export default function ContactInfoTable({ currentSeasonId, allSeasons }) {
 
   return (
     <Box>
-      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
-        {/* Season Dropdown */}
-        {allSeasons && (
-          <FormControl sx={{ minWidth: 200 }}>
-            <InputLabel id="season-select-label">Season</InputLabel>
-            <Select
-              labelId="season-select-label"
-              label="Season"
-              value={selectedSeason}
-              onChange={(e) => setSelectedSeason(e.target.value)}
-            >
-              {seasons.map((season) => (
-                <MenuItem key={season._id} value={season._id}>
-                  {season.name} {season.status === "archived" ? " (Archived)" : ""}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        )}
-
+      <Box sx={{ mb: 2 }}>
         {/* Division Dropdown */}
-        <FormControl sx={{ minWidth: 200 }}>
+        <FormControl 
+          sx={{ 
+            minWidth: 220,
+            '& .MuiOutlinedInput-root': {
+              '&:hover fieldset': {
+                borderColor: MCMASTER_COLORS.maroon,
+              },
+              '&.Mui-focused fieldset': {
+                borderColor: MCMASTER_COLORS.maroon,
+              }
+            },
+            '& .MuiInputLabel-root.Mui-focused': {
+              color: MCMASTER_COLORS.maroon,
+            }
+          }}
+        >
           <InputLabel>Division</InputLabel>
           <Select
             value={selectedDivision}
             label="Division"
             onChange={(e) => setSelectedDivision(e.target.value)}
+            sx={{
+              backgroundColor: 'white',
+            }}
           >
-            <MenuItem value="all">All Divisions</MenuItem>
+            <MenuItem 
+              value="all"
+              sx={{
+                '&.Mui-selected': {
+                  backgroundColor: `${MCMASTER_COLORS.maroon}14`,
+                  '&:hover': {
+                    backgroundColor: `${MCMASTER_COLORS.maroon}20`,
+                  }
+                },
+                '&:hover': {
+                  backgroundColor: `${MCMASTER_COLORS.maroon}0A`,
+                }
+              }}
+            >
+              All Divisions
+            </MenuItem>
             {divisions.map((division) => (
-              <MenuItem key={division} value={division}>
+              <MenuItem 
+                key={division} 
+                value={division}
+                sx={{
+                  '&.Mui-selected': {
+                    backgroundColor: `${MCMASTER_COLORS.maroon}14`,
+                    '&:hover': {
+                      backgroundColor: `${MCMASTER_COLORS.maroon}20`,
+                    }
+                  },
+                  '&:hover': {
+                    backgroundColor: `${MCMASTER_COLORS.maroon}0A`,
+                  }
+                }}
+              >
                 {division}
               </MenuItem>
             ))}
@@ -188,10 +216,17 @@ export default function ContactInfoTable({ currentSeasonId, allSeasons }) {
         </FormControl>
       </Box>
 
-      <TableContainer component={Paper}>
+      <TableContainer 
+        component={Paper}
+        sx={{
+          boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+          border: '1px solid rgba(0,0,0,0.1)',
+          borderRadius: '8px',
+        }}
+      >
         <Table>
           <TableHead>
-            <TableRow>
+            <TableRow sx={{ backgroundColor: MCMASTER_COLORS.lightGrey }}>
               <TableCell><strong>Team Name</strong></TableCell>
               <TableCell><strong>Division</strong></TableCell>
               <TableCell><strong>Captain Name</strong></TableCell>
@@ -207,7 +242,14 @@ export default function ContactInfoTable({ currentSeasonId, allSeasons }) {
                 : "No Captain";
 
               return (
-                <TableRow key={team._id}>
+                <TableRow 
+                  key={team._id}
+                  sx={{
+                    '&:nth-of-type(odd)': {
+                      backgroundColor: 'rgba(0, 0, 0, 0.02)',
+                    },
+                  }}
+                >
                   <TableCell>{team.name}</TableCell>
                   <TableCell>{team.divisionId.name}</TableCell>
                   <TableCell>{captainFullName}</TableCell>

--- a/src/frontend/src/components/NavBar.jsx
+++ b/src/frontend/src/components/NavBar.jsx
@@ -15,8 +15,8 @@ import { useAuth } from "../hooks/AuthProvider";
 import { useNavigate, useLocation } from "react-router";
 import { getPlayerById } from "../api/player";
 
-// McMaster colors
-const MCMASTER_COLORS = {
+// McMaster colours - AI Generated
+const MCMASTER_COLOURS = {
   maroon: '#7A003C',
   grey: '#5E6A71',
   gold: '#FDBF57',
@@ -69,7 +69,7 @@ const NavBar = () => {
   return (
     <AppBar
       position="static"
-      style={{ backgroundColor: MCMASTER_COLORS.maroon, height: 92 }}
+      style={{ backgroundColor: MCMASTER_COLOURS.maroon, height: 92 }}
     >
       <Container style={{ marginTop: "14px" }}>
         <Toolbar disableGutters sx={{ height: 64 }}>
@@ -90,9 +90,9 @@ const NavBar = () => {
               color="inherit" 
               href="/home"
               sx={{ 
-                color: isCurrentPage('/home') ? MCMASTER_COLORS.gold : 'inherit',
+                color: isCurrentPage('/home') ? MCMASTER_COLOURS.gold : 'inherit',
                 '&:hover': {
-                  color: isCurrentPage('/home') ? MCMASTER_COLORS.gold : 'inherit',
+                  color: isCurrentPage('/home') ? MCMASTER_COLOURS.gold : 'inherit',
                 }
               }}
             >
@@ -102,9 +102,9 @@ const NavBar = () => {
               color="inherit" 
               href="/announcements"
               sx={{ 
-                color: isCurrentPage('/announcements') ? MCMASTER_COLORS.gold : 'inherit',
+                color: isCurrentPage('/announcements') ? MCMASTER_COLOURS.gold : 'inherit',
                 '&:hover': {
-                  color: isCurrentPage('/announcements') ? MCMASTER_COLORS.gold : 'inherit',
+                  color: isCurrentPage('/announcements') ? MCMASTER_COLOURS.gold : 'inherit',
                 }
               }}
             >
@@ -115,9 +115,9 @@ const NavBar = () => {
               color="inherit" 
               href={`/team/${teamId}`}
               sx={{ 
-                color: isCurrentPage(`/team/${teamId}`) ? MCMASTER_COLORS.gold : 'inherit',
+                color: isCurrentPage(`/team/${teamId}`) ? MCMASTER_COLOURS.gold : 'inherit',
                 '&:hover': {
-                  color: isCurrentPage(`/team/${teamId}`) ? MCMASTER_COLORS.gold : 'inherit',
+                  color: isCurrentPage(`/team/${teamId}`) ? MCMASTER_COLOURS.gold : 'inherit',
                 }
               }}
             >
@@ -128,9 +128,9 @@ const NavBar = () => {
               color="inherit" 
               href="/schedule"
               sx={{ 
-                color: isCurrentPage('/schedule') ? MCMASTER_COLORS.gold : 'inherit',
+                color: isCurrentPage('/schedule') ? MCMASTER_COLOURS.gold : 'inherit',
                 '&:hover': {
-                  color: isCurrentPage('/schedule') ? MCMASTER_COLORS.gold : 'inherit',
+                  color: isCurrentPage('/schedule') ? MCMASTER_COLOURS.gold : 'inherit',
                 }
               }}
             >
@@ -140,9 +140,9 @@ const NavBar = () => {
               color="inherit" 
               href="/standings"
               sx={{ 
-                color: isCurrentPage('/standings') ? MCMASTER_COLORS.gold : 'inherit',
+                color: isCurrentPage('/standings') ? MCMASTER_COLOURS.gold : 'inherit',
                 '&:hover': {
-                  color: isCurrentPage('/standings') ? MCMASTER_COLORS.gold : 'inherit',
+                  color: isCurrentPage('/standings') ? MCMASTER_COLOURS.gold : 'inherit',
                 }
               }}
             >
@@ -152,9 +152,9 @@ const NavBar = () => {
               color="inherit" 
               href="/info"
               sx={{ 
-                color: isCurrentPage('/info') ? MCMASTER_COLORS.gold : 'inherit',
+                color: isCurrentPage('/info') ? MCMASTER_COLOURS.gold : 'inherit',
                 '&:hover': {
-                  color: isCurrentPage('/info') ? MCMASTER_COLORS.gold : 'inherit',
+                  color: isCurrentPage('/info') ? MCMASTER_COLOURS.gold : 'inherit',
                 }
               }}
             >
@@ -164,9 +164,9 @@ const NavBar = () => {
               color="inherit" 
               href="/documentation"
               sx={{ 
-                color: isCurrentPage('/documentation') ? MCMASTER_COLORS.gold : 'inherit',
+                color: isCurrentPage('/documentation') ? MCMASTER_COLOURS.gold : 'inherit',
                 '&:hover': {
-                  color: isCurrentPage('/documentation') ? MCMASTER_COLORS.gold : 'inherit',
+                  color: isCurrentPage('/documentation') ? MCMASTER_COLOURS.gold : 'inherit',
                 }
               }}
             >
@@ -177,9 +177,9 @@ const NavBar = () => {
               color="inherit" 
               href="/manage"
               sx={{ 
-                color: isCurrentPage('/manage') ? MCMASTER_COLORS.gold : 'inherit',
+                color: isCurrentPage('/manage') ? MCMASTER_COLOURS.gold : 'inherit',
                 '&:hover': {
-                  color: isCurrentPage('/manage') ? MCMASTER_COLORS.gold : 'inherit',
+                  color: isCurrentPage('/manage') ? MCMASTER_COLOURS.gold : 'inherit',
                 }
               }}
             >

--- a/src/frontend/src/components/NavBar.jsx
+++ b/src/frontend/src/components/NavBar.jsx
@@ -12,14 +12,23 @@ import {
 } from "@mui/material";
 import { Person as PersonIcon } from "@mui/icons-material";
 import { useAuth } from "../hooks/AuthProvider";
-import { useNavigate } from "react-router";
+import { useNavigate, useLocation } from "react-router";
 import { getPlayerById } from "../api/player";
+
+// McMaster colors
+const MCMASTER_COLORS = {
+  maroon: '#7A003C',
+  grey: '#5E6A71',
+  gold: '#FDBF57',
+  lightGrey: '#F5F5F5',
+};
 
 const NavBar = () => {
   const [open, setOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState(null);
   const auth = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -52,10 +61,15 @@ const NavBar = () => {
   const handleProfileClick = () => {
     navigate("/profile");
   };
+
+  const isCurrentPage = (path) => {
+    return location.pathname === path;
+  };
+
   return (
     <AppBar
       position="static"
-      style={{ backgroundColor: "#7A003C", height: 92 }}
+      style={{ backgroundColor: MCMASTER_COLORS.maroon, height: 92 }}
     >
       <Container style={{ marginTop: "14px" }}>
         <Toolbar disableGutters sx={{ height: 64 }}>
@@ -72,31 +86,103 @@ const NavBar = () => {
           </Box>
 
           <Box sx={{ display: "flex", gap: 3 }}>
-            <Button color="inherit" href="/home">
+            <Button 
+              color="inherit" 
+              href="/home"
+              sx={{ 
+                color: isCurrentPage('/home') ? MCMASTER_COLORS.gold : 'inherit',
+                '&:hover': {
+                  color: isCurrentPage('/home') ? MCMASTER_COLORS.gold : 'inherit',
+                }
+              }}
+            >
               Home
             </Button>
-            <Button color="inherit" href="/announcements">
+            <Button 
+              color="inherit" 
+              href="/announcements"
+              sx={{ 
+                color: isCurrentPage('/announcements') ? MCMASTER_COLORS.gold : 'inherit',
+                '&:hover': {
+                  color: isCurrentPage('/announcements') ? MCMASTER_COLORS.gold : 'inherit',
+                }
+              }}
+            >
               Announcements
             </Button>
             {role !== "commissioner" && (
-              <Button color="inherit" href={`/team/${teamId}`}>
+              <Button 
+              color="inherit" 
+              href={`/team/${teamId}`}
+              sx={{ 
+                color: isCurrentPage(`/team/${teamId}`) ? MCMASTER_COLORS.gold : 'inherit',
+                '&:hover': {
+                  color: isCurrentPage(`/team/${teamId}`) ? MCMASTER_COLORS.gold : 'inherit',
+                }
+              }}
+            >
                 My Team
               </Button>
             )}
-            <Button color="inherit" href="/schedule">
+            <Button 
+              color="inherit" 
+              href="/schedule"
+              sx={{ 
+                color: isCurrentPage('/schedule') ? MCMASTER_COLORS.gold : 'inherit',
+                '&:hover': {
+                  color: isCurrentPage('/schedule') ? MCMASTER_COLORS.gold : 'inherit',
+                }
+              }}
+            >
               Schedule
             </Button>
-            <Button color="inherit" href="/standings">
+            <Button 
+              color="inherit" 
+              href="/standings"
+              sx={{ 
+                color: isCurrentPage('/standings') ? MCMASTER_COLORS.gold : 'inherit',
+                '&:hover': {
+                  color: isCurrentPage('/standings') ? MCMASTER_COLORS.gold : 'inherit',
+                }
+              }}
+            >
               Standings
             </Button>
-            <Button color="inherit" href="/info">
+            <Button 
+              color="inherit" 
+              href="/info"
+              sx={{ 
+                color: isCurrentPage('/info') ? MCMASTER_COLORS.gold : 'inherit',
+                '&:hover': {
+                  color: isCurrentPage('/info') ? MCMASTER_COLORS.gold : 'inherit',
+                }
+              }}
+            >
               Useful Info
             </Button>
-            <Button color="inherit" href="/documentation">
+            <Button 
+              color="inherit" 
+              href="/documentation"
+              sx={{ 
+                color: isCurrentPage('/documentation') ? MCMASTER_COLORS.gold : 'inherit',
+                '&:hover': {
+                  color: isCurrentPage('/documentation') ? MCMASTER_COLORS.gold : 'inherit',
+                }
+              }}
+            >
               FAQ
             </Button>
             {role === "commissioner" && (
-              <Button color="inherit" href="/manage">
+              <Button 
+              color="inherit" 
+              href="/manage"
+              sx={{ 
+                color: isCurrentPage('/manage') ? MCMASTER_COLORS.gold : 'inherit',
+                '&:hover': {
+                  color: isCurrentPage('/manage') ? MCMASTER_COLORS.gold : 'inherit',
+                }
+              }}
+            >
                 Manage
               </Button>
             )}

--- a/src/frontend/src/components/NotificationsRow.jsx
+++ b/src/frontend/src/components/NotificationsRow.jsx
@@ -96,6 +96,7 @@ export default function NotificationsRow({ notifications: initialNotifications, 
     const isClickable = notification?.type === "reschedule request" || isTeamInvite;
   
     return (
+       // Styling for the notification card (all sx values) - AI generated
       <Paper
         elevation={0}
         sx={{
@@ -108,7 +109,7 @@ export default function NotificationsRow({ notifications: initialNotifications, 
           border: `2px solid ${borderColor}`,
           borderRadius: 4,
           transition: 'all 0.2s ease-in-out',
-          // Hover effect only for clickable cards
+          // Hover effect only for clickable cards 
           ...(isClickable && {
             '&:hover': {
               boxShadow: '0 4px 8px rgba(0,0,0,0.1)',

--- a/src/frontend/src/components/NotificationsRow.jsx
+++ b/src/frontend/src/components/NotificationsRow.jsx
@@ -205,6 +205,8 @@ export default function NotificationsRow({ notifications: initialNotifications, 
                 fontWeight: 400,
                 border: isRead ? `2px solid ${MCMASTER_COLOURS.grey}` : "none",
                 borderRadius: "12px",
+                position: "relative",
+                top: -12
               }}
             />
           </Stack>

--- a/src/frontend/src/components/NotificationsRow.jsx
+++ b/src/frontend/src/components/NotificationsRow.jsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Box,
-  Card,
   CardContent,
   Typography,
   IconButton,
@@ -12,11 +11,28 @@ import {
   DialogContentText,
   DialogTitle,
   Button,
+  Stack,
+  Chip,
+  Paper,
 } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
+import NotificationsIcon from "@mui/icons-material/Notifications";
+import GroupIcon from "@mui/icons-material/Group";
 import { deleteNotification, updateNotificationStatus } from "../api/notification.js";
 import { acceptInvite, getPlayerById } from "../api/player";
 import { useAuth } from "../hooks/AuthProvider";
+
+// MUI envelope icons
+import MarkEmailUnreadIcon from "@mui/icons-material/MarkEmailUnread";
+import MarkEmailReadIcon from "@mui/icons-material/MarkEmailRead";
+
+// McMaster colours
+const MCMASTER_COLOURS = {
+  maroon: '#7A003C',
+  grey: '#5E6A71',
+  gold: '#FDBF57',
+  lightGrey: '#F5F5F5',
+};
 
 export default function NotificationsRow({ notifications: initialNotifications, teamInvites }) {
   const navigate = useNavigate();
@@ -25,6 +41,11 @@ export default function NotificationsRow({ notifications: initialNotifications, 
   const [invites, setInvites] = useState(teamInvites || []);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [selectedNotification, setSelectedNotification] = useState(null);
+
+  // Sort notifications by date
+  const sortedNotifications = [...notifications].sort((a, b) => 
+    new Date(b.createdAt) - new Date(a.createdAt)
+  );
 
   const handleRescheduleClick = async (notification) => {
     await updateNotificationStatus(notification._id, 'read');
@@ -45,17 +66,12 @@ export default function NotificationsRow({ notifications: initialNotifications, 
 
       await acceptInvite(requestBody);
       
-      // Update local state to remove the accepted invite
       setInvites(prevInvites => 
         prevInvites.filter(inv => inv.id !== teamId)
       );
 
-      // Fetch updated player data to ensure the join is processed
       await getPlayerById(auth.playerId);
-
-      // Navigate to waiver page with teamId
       window.location.href = `/waiver?teamId=${teamId}`;
-      console.log("Team invite accepted");
     } catch (err) {
       console.log("Failed to accept team invite");
     }
@@ -73,91 +89,147 @@ export default function NotificationsRow({ notifications: initialNotifications, 
       setDeleteDialogOpen(false);
     }
   };
+  
+  const NotificationCard = ({ notification, isTeamInvite, team }) => {
+    const isRead = notification?.status === "read";
+    const borderColor = isRead ? MCMASTER_COLOURS.grey : MCMASTER_COLOURS.maroon;
+    const isClickable = notification?.type === "reschedule request" || isTeamInvite;
+  
+    return (
+      <Paper
+        elevation={0}
+        sx={{
+          width: 300,
+          height: 120,
+          cursor: isClickable ? "pointer" : "default",
+          position: "relative",
+          mb: 2,
+          backgroundColor: "white",
+          border: `2px solid ${borderColor}`,
+          borderRadius: 4,
+          transition: 'all 0.2s ease-in-out',
+          // Hover effect only for clickable cards
+          ...(isClickable && {
+            '&:hover': {
+              boxShadow: '0 4px 8px rgba(0,0,0,0.1)',
+              '& .hover-text': {
+                opacity: 1,
+              }
+            }
+          })
+        }}
+        onClick={() => {
+          if (isTeamInvite) {
+            handleTeamInviteClick(team.id);
+          } else if (notification?.type === "reschedule request") {
+            handleRescheduleClick(notification);
+          }
+        }}
+      >
+        <CardContent sx={{ p: 2 }}>
+          <Stack direction="row" spacing={1} alignItems="center" mb={1}>
+            {/* Conditionally render envelope icons based on read/unread */}
+            {isRead ? (
+              <MarkEmailReadIcon sx={{ color: borderColor, fontSize: 20 }} />
+            ) : (
+              <MarkEmailUnreadIcon sx={{ color: borderColor, fontSize: 20 }} />
+            )}
+  
+            <Typography
+              sx={{
+                color: borderColor,
+                fontSize: "0.9rem",
+                fontWeight: 500,
+              }}
+            >
+              {isTeamInvite ? "Team Invite" : "Reschedule Request"}
+            </Typography>
+  
+            {/* If not a team invite, show a delete button */}
+            {!isTeamInvite && (
+              <IconButton
+                size="small"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleDeleteClick(notification);
+                }}
+                sx={{
+                  position: "absolute",
+                  top: 12,
+                  right: 12,
+                  color: borderColor,
+                  transition: 'all 0.2s ease-in-out',
+                  '&:hover': {
+                    backgroundColor: `${borderColor}15`,
+                  }
+                }}
+              >
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            )}
+          </Stack>
+  
+          <Typography
+            variant="body2"
+            sx={{
+              color: "text.primary",
+              fontSize: "0.9rem",
+              mb: 1,
+            }}
+          >
+            {isTeamInvite ? `Invitation to join team ${team.name}` : notification.message}
+          </Typography>
+  
+          <Stack direction="row" justifyContent="space-between" alignItems="center">
+            <Typography
+              className="hover-text"
+              sx={{
+                color: borderColor,
+                fontSize: "0.75rem",
+                opacity: 0,
+                transition: 'opacity 0.2s ease-in-out',
+                fontStyle: 'italic'
+              }}
+            >
+              {isTeamInvite ? "Click to accept" : isClickable ? "Click to respond" : ""}
+            </Typography>
+            <Chip
+              label={isRead ? "read" : "unread"}
+              size="small"
+              sx={{
+                backgroundColor: isRead ? "transparent" : MCMASTER_COLOURS.maroon,
+                color: isRead ? MCMASTER_COLOURS.grey : "white",
+                height: 24,
+                fontSize: "0.75rem",
+                fontWeight: 400,
+                border: isRead ? `2px solid ${MCMASTER_COLOURS.grey}` : "none",
+                borderRadius: "12px",
+              }}
+            />
+          </Stack>
+        </CardContent>
+      </Paper>
+    );
+  }
+  
 
   return (
     <>
-      <Box sx={{ display: "flex", gap: 2, overflowX: "auto" }}>
-        {teamInvites ? (
-          // Render team invites
-          invites.map((team, index) => (
-            <Card
-              key={index}
-              sx={{
-                minWidth: 300,
-                cursor: "pointer",
-                transition: "transform 0.2s",
-                "&:hover": { transform: "translateY(-2px)", boxShadow: 3 },
-                position: "relative",
-                mb: 2 // Add margin bottom to prevent cutoff
-              }}
-              onClick={() => handleTeamInviteClick(team.id)}
-            >
-              <CardContent sx={{ pb: 2 }}> {/* Add padding bottom to content */}
-                <Typography variant="h6" gutterBottom>
-                  Team Invite
-                </Typography>
-                <Typography variant="body2" sx={{ mb: 1 }}> {/* Add margin bottom */}
-                  Invitation to join team {team.name}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  Click to accept
-                </Typography>
-              </CardContent>
-            </Card>
-          ))
-        ) : (
-          // Render regular notifications
-          notifications.map((notification, index) => (
-            <Card
-              key={index}
-              sx={{
-                minWidth: 300,
-                cursor: notification.type === "reschedule request" ? "pointer" : "default",
-                transition: notification.type === "reschedule request" ? "transform 0.2s" : "none",
-                "&:hover": notification.type === "reschedule request" ? { transform: "translateY(-2px)", boxShadow: 3 } : {},
-                position: "relative",
-                backgroundColor: notification.status === "read" ? "lightgray" : "white",
-              }}
-              onClick={() => {
-                if (notification.type === "reschedule request") {
-                  handleRescheduleClick(notification);
-                }
-              }}
-            >
-              <CardContent>
-                <Box sx={{ position: "absolute", top: 8, right: 8 }}>
-                  <IconButton
-                    size="small"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleDeleteClick(notification);
-                    }}
-                  >
-                    <DeleteIcon fontSize="small" />
-                  </IconButton>
-                </Box>
-
-                <Typography variant="h6" gutterBottom>
-                  {notification.type || "None"}
-                </Typography>
-
-                <Typography variant="body2">{notification.message}</Typography>
-
-                {notification.type === "reschedule request" && notification.status === 'unread' && (
-                  <Typography variant="caption" color="text.secondary">
-                    Click to respond
-                  </Typography>
-                )}
-
-                <Box sx={{ textAlign: "right", mt: 2 }}>
-                  <Typography variant="caption" sx={{ color: "gray", fontSize: "12px" }}>
-                    {notification.status}
-                  </Typography>
-                </Box>
-              </CardContent>
-            </Card>
-          ))
-        )}
+      <Box sx={{ display: "flex", gap: 2, overflowX: "auto", pb: 2 }}>
+        {teamInvites && invites.map((team, index) => (
+          <NotificationCard 
+            key={index} 
+            isTeamInvite={true} 
+            team={team} 
+          />
+        ))}
+        {sortedNotifications.map((notification, index) => (
+          <NotificationCard 
+            key={index} 
+            notification={notification} 
+            isTeamInvite={false}
+          />
+        ))}
       </Box>
 
       <Dialog open={deleteDialogOpen} onClose={() => setDeleteDialogOpen(false)}>

--- a/src/frontend/src/components/RosterTable.jsx
+++ b/src/frontend/src/components/RosterTable.jsx
@@ -54,17 +54,13 @@ export default function RosterTable(props) {
               key={index}
               sx={{
                 '&:nth-of-type(odd)': {
-                  backgroundColor: `${MCMASTER_COLOURS.maroon}05`,
-                },
-                '&:hover': {
-                  backgroundColor: `${MCMASTER_COLOURS.maroon}0A`,
+                  backgroundColor: 'rgba(0, 0, 0, 0.02)',
                 },
               }}
             >
               <TableCell>
                 {props.captain.id === player.id ? (
                   <Typography sx={{ 
-                    color: MCMASTER_COLOURS.maroon,
                     fontWeight: 600,
                   }}>
                     {player.firstName} {player.lastName}

--- a/src/frontend/src/components/RosterTable.jsx
+++ b/src/frontend/src/components/RosterTable.jsx
@@ -7,12 +7,40 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  Typography,
 } from "@mui/material";
+
+// McMaster colours - AI generated
+const MCMASTER_COLOURS = {
+  maroon: '#7A003C',
+  grey: '#5E6A71',
+  gold: '#FDBF57',
+  lightGrey: '#F5F5F5',
+};
 
 export default function RosterTable(props) {
   return (
-    <TableContainer component={Paper} sx={{ mb: 2, maxHeight: "50vh" }}>
-      <Table>
+    // Styling for the roster table - AI assisted
+    <TableContainer 
+      component={Paper}
+      sx={{
+        boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+        border: '1px solid rgba(0,0,0,0.1)',
+        borderRadius: '8px',
+        mb: 2,
+        maxHeight: "50vh",
+        '& .MuiTableCell-root': {
+          px: 2,
+          py: 1.5,
+        },
+        '& .MuiTableCell-head': {
+          backgroundColor: MCMASTER_COLOURS.maroon,
+          color: 'white',
+          fontWeight: 600,
+        },
+      }}
+    >
+      <Table stickyHeader>
         <TableHead>
           <TableRow>
             <TableCell>Player</TableCell>
@@ -20,17 +48,41 @@ export default function RosterTable(props) {
           </TableRow>
         </TableHead>
         <TableBody>
+          {/* Styling for the table rows - AI generated */}
           {props.roster.map((player, index) => (
-            <TableRow key={index}>
-              {props.captain.id === player.id ? (
-                <TableCell>
-                  {player.firstName} {player.lastName} (Captain){" "}
-                </TableCell>
-              ) : (
-                <TableCell>
-                  {player.firstName} {player.lastName}
-                </TableCell>
-              )}
+            <TableRow 
+              key={index}
+              sx={{
+                '&:nth-of-type(odd)': {
+                  backgroundColor: `${MCMASTER_COLOURS.maroon}05`,
+                },
+                '&:hover': {
+                  backgroundColor: `${MCMASTER_COLOURS.maroon}0A`,
+                },
+              }}
+            >
+              <TableCell>
+                {props.captain.id === player.id ? (
+                  <Typography sx={{ 
+                    color: MCMASTER_COLOURS.maroon,
+                    fontWeight: 600,
+                  }}>
+                    {player.firstName} {player.lastName}
+                    <Typography 
+                      component="span" 
+                      sx={{ 
+                        ml: 0.5,
+                        color: MCMASTER_COLOURS.grey,
+                        fontStyle: 'italic',
+                      }}
+                    >
+                      (Captain)
+                    </Typography>
+                  </Typography>
+                ) : (
+                  `${player.firstName} ${player.lastName}`
+                )}
+              </TableCell>
               <TableCell>{player.email}</TableCell>
             </TableRow>
           ))}

--- a/src/frontend/src/components/ScheduleTable.jsx
+++ b/src/frontend/src/components/ScheduleTable.jsx
@@ -493,9 +493,13 @@ export default function ScheduleTable(props) {
       sx={{ 
         mb: 2,
         maxHeight: "60vh",
+        boxShadow: 'none',
+        border: '1px solid rgba(0,0,0,0.1)',
+        borderRadius: '8px',
         '& .MuiTableCell-root': {
           px: 2,
           py: 1.5,
+          borderColor: 'rgba(0,0,0,0.1)',
         },
         '& .MuiTableCell-head': {
           backgroundColor: MCMASTER_COLOURS.maroon,
@@ -516,7 +520,7 @@ export default function ScheduleTable(props) {
                   whiteSpace: 'nowrap',
                 }}
               >
-                {column.header}
+                <strong>{column.header}</strong>
               </TableCell>
             ))}
           </TableRow>
@@ -529,10 +533,7 @@ export default function ScheduleTable(props) {
                 key={index}
                 sx={{
                   '&:nth-of-type(odd)': {
-                    backgroundColor: `${MCMASTER_COLOURS.maroon}05`,
-                  },
-                  '&:hover': {
-                    backgroundColor: `${MCMASTER_COLOURS.maroon}0A`,
+                    backgroundColor: 'rgba(0, 0, 0, 0.02)',
                   },
                 }}
               >

--- a/src/frontend/src/components/ScheduleTable.jsx
+++ b/src/frontend/src/components/ScheduleTable.jsx
@@ -20,8 +20,8 @@ import {
 import { formatDate, getDayOfWeek } from "../utils/Formatting";
 import { updateScore } from "../api/game.js";
 
-// McMaster colors
-const MCMASTER_COLORS = {
+// McMaster colours - AI Generated
+const MCMASTER_COLOURS = {
   maroon: '#7A003C',
   grey: '#5E6A71',
   gold: '#FDBF57',
@@ -123,13 +123,13 @@ export default function ScheduleTable(props) {
       header: "Game Info",
       accessor: (game) => (
         <Box>
-          <Typography variant="subtitle2" sx={{ color: MCMASTER_COLORS.maroon, fontWeight: 600 }}>
+          <Typography variant="subtitle2" sx={{ color: MCMASTER_COLOURS.maroon, fontWeight: 600 }}>
             {getDayOfWeek(game.date)}
           </Typography>
-          <Typography variant="body2" sx={{ color: MCMASTER_COLORS.grey }}>
+          <Typography variant="body2" sx={{ color: MCMASTER_COLOURS.grey }}>
             {formatDate(game.date)}
           </Typography>
-          <Typography variant="body2" sx={{ color: MCMASTER_COLORS.grey }}>
+          <Typography variant="body2" sx={{ color: MCMASTER_COLOURS.grey }}>
             {game.time} | {game.field}
           </Typography>
         </Box>
@@ -144,9 +144,9 @@ export default function ScheduleTable(props) {
               component="span" 
               variant="caption" 
               sx={{ 
-                color: MCMASTER_COLORS.maroon,
+                color: MCMASTER_COLOURS.maroon,
                 fontWeight: 600,
-                backgroundColor: `${MCMASTER_COLORS.maroon}10`,
+                backgroundColor: `${MCMASTER_COLOURS.maroon}10`,
                 px: 0.5,
                 borderRadius: 0.5
               }}
@@ -162,9 +162,9 @@ export default function ScheduleTable(props) {
               component="span" 
               variant="caption" 
               sx={{ 
-                color: MCMASTER_COLORS.grey,
+                color: MCMASTER_COLOURS.grey,
                 fontWeight: 600,
-                backgroundColor: `${MCMASTER_COLORS.grey}10`,
+                backgroundColor: `${MCMASTER_COLOURS.grey}10`,
                 px: 0.5,
                 borderRadius: 0.5
               }}
@@ -175,7 +175,7 @@ export default function ScheduleTable(props) {
               {game.awayTeam.name}
             </Typography>
           </Box>
-          <Typography variant="caption" sx={{ color: MCMASTER_COLORS.grey, display: 'block', mt: 0.5 }}>
+          <Typography variant="caption" sx={{ color: MCMASTER_COLOURS.grey, display: 'block', mt: 0.5 }}>
             Division {game.division.name}
           </Typography>
         </Box>
@@ -425,12 +425,12 @@ export default function ScheduleTable(props) {
                 size="small"
                 onClick={handleCancel}
                 sx={{
-                  borderColor: MCMASTER_COLORS.grey,
-                  color: MCMASTER_COLORS.grey,
+                  borderColor: MCMASTER_COLOURS.grey,
+                  color: MCMASTER_COLOURS.grey,
                   minWidth: '80px',
                   '&:hover': {
-                    borderColor: MCMASTER_COLORS.grey,
-                    backgroundColor: `${MCMASTER_COLORS.grey}10`,
+                    borderColor: MCMASTER_COLOURS.grey,
+                    backgroundColor: `${MCMASTER_COLOURS.grey}10`,
                   },
                 }}
               >
@@ -443,13 +443,13 @@ export default function ScheduleTable(props) {
               onClick={handleButtonClick}
               disabled={getIsDisabled()}
               sx={{
-                backgroundColor: MCMASTER_COLORS.maroon,
+                backgroundColor: MCMASTER_COLOURS.maroon,
                 minWidth: '80px',
                 '&:hover': {
                   backgroundColor: '#5C002E',
                 },
                 '&.Mui-disabled': {
-                  backgroundColor: `${MCMASTER_COLORS.grey}80`,
+                  backgroundColor: `${MCMASTER_COLOURS.grey}80`,
                 }
               }}
             >
@@ -463,13 +463,13 @@ export default function ScheduleTable(props) {
             onClick={handleButtonClick}
             disabled={getIsDisabled()}
             sx={{
-              backgroundColor: MCMASTER_COLORS.maroon,
+              backgroundColor: MCMASTER_COLOURS.maroon,
               minWidth: '80px',
               '&:hover': {
                 backgroundColor: '#5C002E',
               },
               '&.Mui-disabled': {
-                backgroundColor: `${MCMASTER_COLORS.grey}80`,
+                backgroundColor: `${MCMASTER_COLOURS.grey}80`,
               }
             }}
           >
@@ -498,7 +498,7 @@ export default function ScheduleTable(props) {
           py: 1.5,
         },
         '& .MuiTableCell-head': {
-          backgroundColor: MCMASTER_COLORS.maroon,
+          backgroundColor: MCMASTER_COLOURS.maroon,
           color: 'white',
           fontWeight: 600,
         },
@@ -529,10 +529,10 @@ export default function ScheduleTable(props) {
                 key={index}
                 sx={{
                   '&:nth-of-type(odd)': {
-                    backgroundColor: `${MCMASTER_COLORS.maroon}05`,
+                    backgroundColor: `${MCMASTER_COLOURS.maroon}05`,
                   },
                   '&:hover': {
-                    backgroundColor: `${MCMASTER_COLORS.maroon}0A`,
+                    backgroundColor: `${MCMASTER_COLOURS.maroon}0A`,
                   },
                 }}
               >
@@ -549,7 +549,7 @@ export default function ScheduleTable(props) {
           ) : (
             <TableRow>
               <TableCell colSpan={visibleColumns.length} align="center">
-                <Typography sx={{ py: 2, color: MCMASTER_COLORS.grey }}>
+                <Typography sx={{ py: 2, color: MCMASTER_COLOURS.grey }}>
                   No games scheduled.
                 </Typography>
               </TableCell>
@@ -559,7 +559,7 @@ export default function ScheduleTable(props) {
       </Table>
     </TableContainer>
   ) : (
-    <Typography variant="h6" sx={{ mb: 2, color: MCMASTER_COLORS.grey }}>
+    <Typography variant="h6" sx={{ mb: 2, color: MCMASTER_COLOURS.grey }}>
       No Schedule Available: email the commissioner if this is an unexpected error.
     </Typography>
   );

--- a/src/frontend/src/components/ScheduleTable.jsx
+++ b/src/frontend/src/components/ScheduleTable.jsx
@@ -15,9 +15,18 @@ import {
   Radio,
   RadioGroup,
   Typography,
+  Box,
 } from "@mui/material";
 import { formatDate, getDayOfWeek } from "../utils/Formatting";
 import { updateScore } from "../api/game.js";
+
+// McMaster colors
+const MCMASTER_COLORS = {
+  maroon: '#7A003C',
+  grey: '#5E6A71',
+  gold: '#FDBF57',
+  lightGrey: '#F5F5F5',
+};
 
 export default function ScheduleTable(props) {
   const [scores, setScores] = useState({});
@@ -111,206 +120,228 @@ export default function ScheduleTable(props) {
   // Define columns
   const columns = [
     {
-      header: "Day of Week",
-      accessor: (game) => getDayOfWeek(game.date),
+      header: "Game Info",
+      accessor: (game) => (
+        <Box>
+          <Typography variant="subtitle2" sx={{ color: MCMASTER_COLORS.maroon, fontWeight: 600 }}>
+            {getDayOfWeek(game.date)}
+          </Typography>
+          <Typography variant="body2" sx={{ color: MCMASTER_COLORS.grey }}>
+            {formatDate(game.date)}
+          </Typography>
+          <Typography variant="body2" sx={{ color: MCMASTER_COLORS.grey }}>
+            {game.time} | {game.field}
+          </Typography>
+        </Box>
+      ),
     },
     {
-      header: "Date",
-      accessor: (game) => formatDate(game.date),
+      header: "Teams",
+      accessor: (game) => (
+        <Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <Typography 
+              component="span" 
+              variant="caption" 
+              sx={{ 
+                color: MCMASTER_COLORS.maroon,
+                fontWeight: 600,
+                backgroundColor: `${MCMASTER_COLORS.maroon}10`,
+                px: 0.5,
+                borderRadius: 0.5
+              }}
+            >
+              HOME
+            </Typography>
+            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+              {game.homeTeam.name}
+            </Typography>
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
+            <Typography 
+              component="span" 
+              variant="caption" 
+              sx={{ 
+                color: MCMASTER_COLORS.grey,
+                fontWeight: 600,
+                backgroundColor: `${MCMASTER_COLORS.grey}10`,
+                px: 0.5,
+                borderRadius: 0.5
+              }}
+            >
+              AWAY
+            </Typography>
+            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+              {game.awayTeam.name}
+            </Typography>
+          </Box>
+          <Typography variant="caption" sx={{ color: MCMASTER_COLORS.grey, display: 'block', mt: 0.5 }}>
+            Division {game.division.name}
+          </Typography>
+        </Box>
+      ),
     },
-    { header: "Time", accessor: (game) => game.time },
-    { header: "Field", accessor: (game) => game.field },
-    { header: "Division", accessor: (game) => game.division.name },
-    { header: "Home", accessor: (game) => game.homeTeam.name },
-    { header: "Away", accessor: (game) => game.awayTeam.name },
     {
-      header: "Default Loss?",
+      header: "Default Loss",
       accessor: (game) => {
         const gameId = game._id;
         const { isDefaultLoss = false, team = null } = defaultLossOptions[gameId] || {};
         const isEditting = editMode[gameId];
 
-        return (
-          <Checkbox
-            checked={isDefaultLoss}
-            disabled={!isEditting}
-            onChange={(e) => {
-              const checked = e.target.checked;
-              setDefaultLossOptions((prev) => ({
-                ...prev,
-                [gameId]: {
-                  ...prev[gameId],
-                  isDefaultLoss: checked,
-                  // If turning on default loss, pick whichever team you want or none
-                  team: checked ? prev[gameId]?.team || null : null,
-                },
-              }));
-
-              // // If turning it on, also set default scores
-              // if (checked) {
-              //   // Suppose away lost by default: away=1, home=9
-              //   setScores((prevScores) => ({
-              //     ...prevScores,
-              //     [gameId]: {
-              //       ...prevScores[gameId],
-              //       home: 9,
-              //       away: 1,
-              //     },
-              //   }));
-              // } else {
-              if (!checked) { // If user unchecked, reset to blank
-                setScores((prevScores) => ({
-                  ...prevScores,
-                  [gameId]: {
-                    ...prevScores[gameId],
-                    home: "",
-                    away: "",
-                  },
-                }));
+        return isEditting ? (
+          <Box>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={isDefaultLoss}
+                  disabled={!isEditting}
+                  size="small"
+                  onChange={(e) => {
+                    const checked = e.target.checked;
+                    setDefaultLossOptions((prev) => ({
+                      ...prev,
+                      [gameId]: {
+                        ...prev[gameId],
+                        isDefaultLoss: checked,
+                        team: checked ? prev[gameId]?.team || null : null,
+                      },
+                    }));
+                    if (!checked) {
+                      setScores((prevScores) => ({
+                        ...prevScores,
+                        [gameId]: {
+                          ...prevScores[gameId],
+                          home: "",
+                          away: "",
+                        },
+                      }));
+                    }
+                  }}
+                />
               }
-            }}
-          />
-        );
+              label="Default Loss"
+            />
+            {isDefaultLoss && (
+              <FormControl component="fieldset" size="small">
+                <RadioGroup
+                  row
+                  value={team === game.homeTeam._id ? "home" : team === game.awayTeam._id ? "away" : ""}
+                  onChange={(e) => {
+                    const teamVal = e.target.value;
+                    const teamId = teamVal === "home" ? game.homeTeam._id : game.awayTeam._id;
+
+                    setDefaultLossOptions((prev) => ({
+                      ...prev,
+                      [gameId]: {
+                        ...prev[gameId],
+                        team: teamId,
+                      },
+                    }));
+
+                    setScores((prevScores) => ({
+                      ...prevScores,
+                      [gameId]: {
+                        ...prevScores[gameId],
+                        home: teamVal === "home" ? 1 : 9,
+                        away: teamVal === "away" ? 1 : 9,
+                      },
+                    }));
+                  }}
+                >
+                  <FormControlLabel value="home" control={<Radio size="small" />} label="Home" />
+                  <FormControlLabel value="away" control={<Radio size="small" />} label="Away" />
+                </RadioGroup>
+              </FormControl>
+            )}
+          </Box>
+        ) : isDefaultLoss ? (
+          <Typography variant="body2" sx={{ color: 'error.main' }}>
+            {team === game.homeTeam._id ? game.homeTeam.name : game.awayTeam.name} (Default Loss)
+          </Typography>
+        ) : null;
       },
       shouldShow:
         isCaptain || (props.role === "commissioner" && !props.archived),
     },
     {
-      header: "Lost By?",
-      accessor: (game) => {
-        const gameId = game._id;
-        const isDefaultLoss = defaultLossOptions[gameId]?.isDefaultLoss || false;
-        const isEditting = editMode[gameId];
-
-        // Convert stored ID to "home"/"away" for UI
-        const selectedTeamId = defaultLossOptions[gameId]?.team;
-        let radioVal = "";
-        if (selectedTeamId === game.homeTeam._id) radioVal = "home";
-        if (selectedTeamId === game.awayTeam._id) radioVal = "away";
-
-        // Only enable if default loss is checked
-        return (
-          <FormControl component="fieldset" disabled={!isEditting || !isDefaultLoss}>
-            <RadioGroup
-              row
-              value={radioVal} 
-              onChange={(e) => {
-                const teamVal = e.target.value; // "home" or "away"
-                const teamId = teamVal === "home" ? game.homeTeam._id : game.awayTeam._id; // Store actual ID
-
-                setDefaultLossOptions((prev) => ({
-                  ...prev,
-                  [gameId]: {
-                    ...prev[gameId],
-                    team: teamId,
-                  },
-                }));
-
-                // Set default scores based on who lost
-                setScores((prevScores) => ({
-                  ...prevScores,
-                  [gameId]: {
-                    ...prevScores[gameId],
-                    home: teamVal === "home" ? 1 : 9,
-                    away: teamVal === "away" ? 1 : 9,
-                  },
-                }));
-              }}
-            >
-              <FormControlLabel value="home" control={<Radio />} label="Home" />
-              <FormControlLabel value="away" control={<Radio />} label="Away" />
-            </RadioGroup>
-          </FormControl>
-        );
-      },
-      shouldShow:
-        isCaptain || (props.role === "commissioner" && !props.archived),
-    },
-    {
-      header: "Home Score",
+      header: "Score",
       accessor: (game) => {
         const gameId = game._id;
         const isEditting = editMode[gameId];
         const homeScore = scores[gameId]?.home ?? game.homeScore ?? "";
-        const isDefaultLoss = defaultLossOptions[gameId]?.isDefaultLoss || false;    
-        
-        // If user is not a captain/commissioner or if game is archived, just show the score as text
-        if ((!isCaptain && props.role !== "commissioner") || props.archived) {
-          return homeScore || "-";
-        }
-        
-        return (
-          <TextField
-            value={homeScore || ""}
-            onChange={(e) => handleScoreChange(gameId, "home", e.target.value)}
-            size="small"
-            variant="outlined"
-            type="number"
-            inputProps={{
-              maxLength: 2,
-              inputMode: "numeric",
-              pattern: "[0-9]*",
-              min: 0,
-              max: 99,
-              style: { color: 'inherit' },
-            }}
-            sx={{ 
-              width: "60px",
-              "& .Mui-disabled": {
-                WebkitTextFillColor: 'inherit',
-                color: 'inherit',
-              },
-              "& .MuiInputBase-input.Mui-disabled": {
-                WebkitTextFillColor: 'inherit',
-                color: 'inherit',
-              }
-            }}
-            disabled={!isEditting || isDefaultLoss}
-          />
-        );
-      },
-    },
-    {
-      header: "Away Score",
-      accessor: (game) => {
-        const gameId = game._id;
-        const isEditting = editMode[gameId];
         const awayScore = scores[gameId]?.away ?? game.awayScore ?? "";
         const isDefaultLoss = defaultLossOptions[gameId]?.isDefaultLoss || false;
 
-        // If user is not a captain/commissioner or if game is archived, just show the score as text
         if ((!isCaptain && props.role !== "commissioner") || props.archived) {
-          return awayScore || "-";
+          return (
+            <Typography variant="body2">
+              {homeScore || "-"} - {awayScore || "-"}
+            </Typography>
+          );
         }
 
-        return (
-          <TextField
-            value={awayScore || ""}
-            onChange={(e) => handleScoreChange(gameId, "away", e.target.value)}
-            size="small"
-            variant="outlined"
-            type="number"
-            inputProps={{
-              maxLength: 2,
-              inputMode: "numeric",
-              pattern: "[0-9]*",
-              min: 0,
-              max: 99,
-              style: { color: 'inherit' },
-            }}
-            sx={{ 
-              width: "60px",
-              "& .Mui-disabled": {
-                WebkitTextFillColor: 'inherit',
-                color: 'inherit',
-              },
-              "& .MuiInputBase-input.Mui-disabled": {
-                WebkitTextFillColor: 'inherit',
-                color: 'inherit',
-              }
-            }}
-            disabled={!isEditting || isDefaultLoss}
-          />
+        return isEditting ? (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <TextField
+              value={homeScore || ""}
+              onChange={(e) => handleScoreChange(gameId, "home", e.target.value)}
+              size="small"
+              variant="outlined"
+              type="number"
+              inputProps={{
+                maxLength: 2,
+                inputMode: "numeric",
+                pattern: "[0-9]*",
+                min: 0,
+                max: 99,
+                style: { color: 'inherit' },
+              }}
+              sx={{ 
+                width: "60px",
+                "& .Mui-disabled": {
+                  WebkitTextFillColor: 'inherit',
+                  color: 'inherit',
+                },
+                "& .MuiInputBase-input.Mui-disabled": {
+                  WebkitTextFillColor: 'inherit',
+                  color: 'inherit',
+                }
+              }}
+              disabled={isDefaultLoss}
+            />
+            <Typography variant="body1">-</Typography>
+            <TextField
+              value={awayScore || ""}
+              onChange={(e) => handleScoreChange(gameId, "away", e.target.value)}
+              size="small"
+              variant="outlined"
+              type="number"
+              inputProps={{
+                maxLength: 2,
+                inputMode: "numeric",
+                pattern: "[0-9]*",
+                min: 0,
+                max: 99,
+                style: { color: 'inherit' },
+              }}
+              sx={{ 
+                width: "60px",
+                "& .Mui-disabled": {
+                  WebkitTextFillColor: 'inherit',
+                  color: 'inherit',
+                },
+                "& .MuiInputBase-input.Mui-disabled": {
+                  WebkitTextFillColor: 'inherit',
+                  color: 'inherit',
+                }
+              }}
+              disabled={isDefaultLoss}
+            />
+          </Box>
+        ) : (
+          <Typography variant="body2">
+            {homeScore || "-"} - {awayScore || "-"}
+          </Typography>
         );
       },
     },
@@ -319,7 +350,30 @@ export default function ScheduleTable(props) {
       accessor: (game) => {
         const gameId = game._id;
         const isEditting = editMode[gameId];
-        const buttonLabel = isEditting ? "Submit Score" : "Edit Score";
+        const buttonLabel = isEditting ? "Submit" : "Edit";
+        const wasSubmitted = scores[gameId]?.submitted;
+
+        const handleCancel = () => {
+          // Reset scores to original values
+          setScores((prevScores) => ({
+            ...prevScores,
+            [gameId]: {
+              home: game.homeScore,
+              away: game.awayScore,
+              submitted: true
+            }
+          }));
+          // Reset default loss options
+          setDefaultLossOptions((prev) => ({
+            ...prev,
+            [gameId]: {
+              isDefaultLoss: game.defaultLossTeam ? true : false,
+              team: game.defaultLossTeam ? game.defaultLossTeam.toString() : null
+            }
+          }));
+          // Exit edit mode
+          toggleEditMode(gameId);
+        };
 
         // Evaluate if the button is disabled
         const getIsDisabled = () => {
@@ -363,17 +417,61 @@ export default function ScheduleTable(props) {
           }
         };       
 
-        return (
+        return isEditting ? (
+          <Box sx={{ display: 'flex', gap: 1, justifyContent: 'center' }}>
+            {wasSubmitted && (
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={handleCancel}
+                sx={{
+                  borderColor: MCMASTER_COLORS.grey,
+                  color: MCMASTER_COLORS.grey,
+                  minWidth: '80px',
+                  '&:hover': {
+                    borderColor: MCMASTER_COLORS.grey,
+                    backgroundColor: `${MCMASTER_COLORS.grey}10`,
+                  },
+                }}
+              >
+                Cancel
+              </Button>
+            )}
+            <Button
+              variant="contained"
+              size="small"
+              onClick={handleButtonClick}
+              disabled={getIsDisabled()}
+              sx={{
+                backgroundColor: MCMASTER_COLORS.maroon,
+                minWidth: '80px',
+                '&:hover': {
+                  backgroundColor: '#5C002E',
+                },
+                '&.Mui-disabled': {
+                  backgroundColor: `${MCMASTER_COLORS.grey}80`,
+                }
+              }}
+            >
+              {buttonLabel}
+            </Button>
+          </Box>
+        ) : (
           <Button
             variant="contained"
-            sx={{
-              backgroundColor: "#7A003C",
-              color: "white",
-              "&:hover": { backgroundColor: "#5A002C" },
-            }}
             size="small"
             onClick={handleButtonClick}
             disabled={getIsDisabled()}
+            sx={{
+              backgroundColor: MCMASTER_COLORS.maroon,
+              minWidth: '80px',
+              '&:hover': {
+                backgroundColor: '#5C002E',
+              },
+              '&.Mui-disabled': {
+                backgroundColor: `${MCMASTER_COLORS.grey}80`,
+              }
+            }}
           >
             {buttonLabel}
           </Button>
@@ -390,13 +488,36 @@ export default function ScheduleTable(props) {
   );
 
   return props.schedule ? (
-    <TableContainer component={Paper} sx={{ mb: 2, maxHeight: "50vh" }}>
-      <Table stickyHeader>
+    <TableContainer 
+      component={Paper} 
+      sx={{ 
+        mb: 2,
+        maxHeight: "60vh",
+        '& .MuiTableCell-root': {
+          px: 2,
+          py: 1.5,
+        },
+        '& .MuiTableCell-head': {
+          backgroundColor: MCMASTER_COLORS.maroon,
+          color: 'white',
+          fontWeight: 600,
+        },
+      }}
+    >
+      <Table stickyHeader size="small">
         <TableHead>
           <TableRow>
             {/* Map over columns for headers */}
             {visibleColumns.map((column, index) => (
-              <TableCell key={index}>{column.header}</TableCell>
+              <TableCell 
+                key={index}
+                align={column.header === "Action" ? "center" : "left"}
+                sx={{
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {column.header}
+              </TableCell>
             ))}
           </TableRow>
         </TableHead>
@@ -404,9 +525,22 @@ export default function ScheduleTable(props) {
           {/* Map through the games */}
           {props.schedule.games && props.schedule.games.length > 0 ? (
             props.schedule.games.map((game, index) => (
-              <TableRow key={index}>
+              <TableRow 
+                key={index}
+                sx={{
+                  '&:nth-of-type(odd)': {
+                    backgroundColor: `${MCMASTER_COLORS.maroon}05`,
+                  },
+                  '&:hover': {
+                    backgroundColor: `${MCMASTER_COLORS.maroon}0A`,
+                  },
+                }}
+              >
                 {visibleColumns.map((column, colIndex) => (
-                  <TableCell key={colIndex} sx={{ height: 12 }}>
+                  <TableCell 
+                    key={colIndex}
+                    align={column.header === "Action" ? "center" : "left"}
+                  >
                     {column.accessor(game)}
                   </TableCell>
                 ))}
@@ -414,8 +548,10 @@ export default function ScheduleTable(props) {
             ))
           ) : (
             <TableRow>
-              <TableCell colSpan={columns.length} align="center">
-                No games scheduled.
+              <TableCell colSpan={visibleColumns.length} align="center">
+                <Typography sx={{ py: 2, color: MCMASTER_COLORS.grey }}>
+                  No games scheduled.
+                </Typography>
               </TableCell>
             </TableRow>
           )}
@@ -423,7 +559,7 @@ export default function ScheduleTable(props) {
       </Table>
     </TableContainer>
   ) : (
-    <Typography variant="h6" sx={{ mb: 2 }}>
+    <Typography variant="h6" sx={{ mb: 2, color: MCMASTER_COLORS.grey }}>
       No Schedule Available: email the commissioner if this is an unexpected error.
     </Typography>
   );

--- a/src/frontend/src/components/ScheduleTable.jsx
+++ b/src/frontend/src/components/ScheduleTable.jsx
@@ -252,9 +252,20 @@ export default function ScheduleTable(props) {
               pattern: "[0-9]*",
               min: 0,
               max: 99,
+              style: { color: 'inherit' },
             }}
-            sx={{ width: "60px" }} // Set the width for compact appearance
-            disabled={!isEditting || isDefaultLoss} // Disable if the score is submitted or default loss was checked
+            sx={{ 
+              width: "60px",
+              "& .Mui-disabled": {
+                WebkitTextFillColor: 'inherit',
+                color: 'inherit',
+              },
+              "& .MuiInputBase-input.Mui-disabled": {
+                WebkitTextFillColor: 'inherit',
+                color: 'inherit',
+              }
+            }}
+            disabled={!isEditting || isDefaultLoss}
           />
         );
       },
@@ -285,9 +296,20 @@ export default function ScheduleTable(props) {
               pattern: "[0-9]*",
               min: 0,
               max: 99,
+              style: { color: 'inherit' },
             }}
-            sx={{ width: "60px" }} // Set the width for compact appearance
-            disabled={!isEditting || isDefaultLoss} // Disable if the score is submitted
+            sx={{ 
+              width: "60px",
+              "& .Mui-disabled": {
+                WebkitTextFillColor: 'inherit',
+                color: 'inherit',
+              },
+              "& .MuiInputBase-input.Mui-disabled": {
+                WebkitTextFillColor: 'inherit',
+                color: 'inherit',
+              }
+            }}
+            disabled={!isEditting || isDefaultLoss}
           />
         );
       },

--- a/src/frontend/src/components/StandingsTable.jsx
+++ b/src/frontend/src/components/StandingsTable.jsx
@@ -9,31 +9,78 @@ import {
   TableBody,
 } from "@mui/material";
 
+// McMaster colours - AI generated
+const MCMASTER_COLOURS = {
+  maroon: '#7A003C',
+  grey: '#5E6A71',
+  gold: '#FDBF57',
+  lightGrey: '#F5F5F5',
+};
+
 export default function StandingsTable({ standings }) {
   const standingColumns = ["Rank", "Team", "PTS", "W", "D", "L", "RS", "RA", "Run Diff", "Losses by Default"];//, "No Show Shame"];
   const standingKeys = ["rank", "team", "p", "w", "d", "l", "rs", "ra", "differential", "dl"];//, "noshows"];
 
   return (
-    <TableContainer component={Paper} sx={{ mb: 4 }}>
+    // Standings table styling - AI generated
+    <TableContainer 
+      component={Paper} 
+      sx={{ 
+        mb: 4,
+        boxShadow: 'none',
+        border: '1px solid rgba(0, 0, 0, 0.1)',
+        borderRadius: '8px',
+        '& .MuiTableCell-root': {
+          px: 2,
+          py: 1.5,
+          borderColor: 'rgba(0,0,0,0.1)',
+        },
+        '& .MuiTableCell-head': {
+          backgroundColor: MCMASTER_COLOURS.maroon,
+          color: 'white',
+          fontWeight: 600,
+        },
+      }}
+    >
       <Table>
         <TableHead>
           <TableRow>
             {standingColumns.map((column, index) => (
-              <TableCell key={index}>{column}</TableCell>
+              <TableCell key={index} align={index > 1 ? "center" : "left"}>
+                <strong>{column}</strong>
+              </TableCell>
             ))}
           </TableRow>
         </TableHead>
         <TableBody>
           {standings.map((standingRow, rowIndex) => (
-            <TableRow key={rowIndex}>
+            <TableRow 
+              key={rowIndex}
+              sx={{
+                '&:nth-of-type(odd)': {
+                  backgroundColor: 'rgba(0, 0, 0, 0.02)',
+                },
+                '&:last-child td, &:last-child th': { 
+                  borderBottom: 0 
+                },
+              }}
+            >
               {standingKeys.map((key, colIndex) => (
-                <TableCell key={colIndex}>
+                <TableCell 
+                  key={colIndex} 
+                  align={colIndex > 1 ? "center" : "left"}
+                  sx={{
+                    ...(key === "team" && {
+                      fontWeight: 500,
+                    })
+                  }}
+                >
                   {key === "team"
-                    ? standingRow.team?.name || "Unknown" // handle missing team names
+                    ? standingRow.team?.name || "Unknown"
                     : key === "differential"
                     ? standingRow.differential > 0
-                      ? `+${standingRow.differential}` // add "+" for positive values
-                      : standingRow.differential // show as is for negative/zero
+                      ? `+${standingRow.differential}`
+                      : standingRow.differential
                     : standingRow[key] ?? "N/A"}
                 </TableCell>
               ))}

--- a/src/frontend/src/components/manage/CommissionerContactInfo.jsx
+++ b/src/frontend/src/components/manage/CommissionerContactInfo.jsx
@@ -5,9 +5,18 @@ import {
   InputLabel,
   Select,
   MenuItem,
-  Typography
+  Typography,
+  Paper
 } from "@mui/material";
 import ContactInfoTable from "../ContactInfoTable";
+
+// McMaster colors
+const MCMASTER_COLORS = {
+  maroon: '#7A003C',
+  grey: '#5E6A71',
+  gold: '#FDBF57',
+  lightGrey: '#F5F5F5',
+};
 
 export default function CommissionerContactInfo({ seasons }) {
   const [selectedSeason, setSelectedSeason] = useState("");
@@ -20,12 +29,97 @@ export default function CommissionerContactInfo({ seasons }) {
   }, [seasons]);
 
   if (!seasons || seasons.length === 0) {
-    return <Typography>No seasons available</Typography>;
+    return (
+      <Box 
+        sx={{ 
+          p: 4, 
+          textAlign: 'center',
+          color: MCMASTER_COLORS.grey,
+          bgcolor: MCMASTER_COLORS.lightGrey,
+          borderRadius: 2
+        }}
+      >
+        <Typography variant="h6">No seasons available</Typography>
+      </Box>
+    );
   }
 
   return (
     <Box>
-      <ContactInfoTable currentSeasonId={selectedSeason} allSeasons={seasons} />
+      <Paper 
+        sx={{ 
+          p: 3, 
+          mb: 4,
+          boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+          border: '1px solid rgba(0,0,0,0.1)',
+          borderRadius: '8px',
+          bgcolor: 'white'
+        }}
+      >
+        <Typography 
+          variant="h4" 
+          component="h2" 
+          sx={{ 
+            color: MCMASTER_COLORS.maroon,
+            fontWeight: 700,
+            mb: 3,
+            fontSize: '2rem'
+          }}
+        >
+          Team Contact Information
+        </Typography>
+
+        <FormControl 
+          sx={{ 
+            minWidth: 220,
+            mb: 4,
+            '& .MuiOutlinedInput-root': {
+              '&:hover fieldset': {
+                borderColor: MCMASTER_COLORS.maroon,
+              },
+              '&.Mui-focused fieldset': {
+                borderColor: MCMASTER_COLORS.maroon,
+              }
+            },
+            '& .MuiInputLabel-root.Mui-focused': {
+              color: MCMASTER_COLORS.maroon,
+            }
+          }}
+        >
+          <InputLabel>Season</InputLabel>
+          <Select
+            value={selectedSeason}
+            label="Season"
+            onChange={(e) => setSelectedSeason(e.target.value)}
+          >
+            {seasons.map((season) => (
+              <MenuItem 
+                key={season._id} 
+                value={season._id}
+                sx={{
+                  '&.Mui-selected': {
+                    backgroundColor: `${MCMASTER_COLORS.maroon}14`,
+                    '&:hover': {
+                      backgroundColor: `${MCMASTER_COLORS.maroon}20`,
+                    }
+                  },
+                  '&:hover': {
+                    backgroundColor: `${MCMASTER_COLORS.maroon}0A`,
+                  }
+                }}
+              >
+                {season.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        {selectedSeason && (
+          <Box sx={{ mt: 2 }}>
+            <ContactInfoTable currentSeasonId={selectedSeason} allSeasons={seasons} />
+          </Box>
+        )}
+      </Paper>
     </Box>
   );
 } 

--- a/src/frontend/src/components/manage/CommissionerContactInfo.jsx
+++ b/src/frontend/src/components/manage/CommissionerContactInfo.jsx
@@ -10,8 +10,8 @@ import {
 } from "@mui/material";
 import ContactInfoTable from "../ContactInfoTable";
 
-// McMaster colors
-const MCMASTER_COLORS = {
+// McMaster colours - AI Generated
+const MCMASTER_COLOURS = {
   maroon: '#7A003C',
   grey: '#5E6A71',
   gold: '#FDBF57',
@@ -34,8 +34,8 @@ export default function CommissionerContactInfo({ seasons }) {
         sx={{ 
           p: 4, 
           textAlign: 'center',
-          color: MCMASTER_COLORS.grey,
-          bgcolor: MCMASTER_COLORS.lightGrey,
+          color: MCMASTER_COLOURS.grey,
+          bgcolor: MCMASTER_COLOURS.lightGrey,
           borderRadius: 2
         }}
       >
@@ -60,7 +60,7 @@ export default function CommissionerContactInfo({ seasons }) {
           variant="h4" 
           component="h2" 
           sx={{ 
-            color: MCMASTER_COLORS.maroon,
+            color: MCMASTER_COLOURS.maroon,
             fontWeight: 700,
             mb: 3,
             fontSize: '2rem'
@@ -75,14 +75,14 @@ export default function CommissionerContactInfo({ seasons }) {
             mb: 4,
             '& .MuiOutlinedInput-root': {
               '&:hover fieldset': {
-                borderColor: MCMASTER_COLORS.maroon,
+                borderColor: MCMASTER_COLOURS.maroon,
               },
               '&.Mui-focused fieldset': {
-                borderColor: MCMASTER_COLORS.maroon,
+                borderColor: MCMASTER_COLOURS.maroon,
               }
             },
             '& .MuiInputLabel-root.Mui-focused': {
-              color: MCMASTER_COLORS.maroon,
+              color: MCMASTER_COLOURS.maroon,
             }
           }}
         >
@@ -98,13 +98,13 @@ export default function CommissionerContactInfo({ seasons }) {
                 value={season._id}
                 sx={{
                   '&.Mui-selected': {
-                    backgroundColor: `${MCMASTER_COLORS.maroon}14`,
+                    backgroundColor: `${MCMASTER_COLOURS.maroon}14`,
                     '&:hover': {
-                      backgroundColor: `${MCMASTER_COLORS.maroon}20`,
+                      backgroundColor: `${MCMASTER_COLOURS.maroon}20`,
                     }
                   },
                   '&:hover': {
-                    backgroundColor: `${MCMASTER_COLORS.maroon}0A`,
+                    backgroundColor: `${MCMASTER_COLOURS.maroon}0A`,
                   }
                 }}
               >

--- a/src/frontend/src/components/manage/CreateSeasonForm.jsx
+++ b/src/frontend/src/components/manage/CreateSeasonForm.jsx
@@ -2,8 +2,8 @@ import React, { useState } from "react";
 import { Paper, Button, TextField, Snackbar, Alert, Grid } from "@mui/material";
 import { createSeason, getAllSeasons } from "../../api/season";
 
-// McMaster colors
-const MCMASTER_COLORS = {
+// McMaster colours - AI Generated
+const MCMASTER_COLOURS = {
   maroon: '#7A003C',
   grey: '#5E6A71',
   gold: '#FDBF57',
@@ -64,14 +64,14 @@ const CreateSeasonForm = (props) => {
   const textFieldStyles = {
     '& .MuiOutlinedInput-root': {
       '&:hover fieldset': {
-        borderColor: MCMASTER_COLORS.maroon,
+        borderColor: MCMASTER_COLOURS.maroon,
       },
       '&.Mui-focused fieldset': {
-        borderColor: MCMASTER_COLORS.maroon,
+        borderColor: MCMASTER_COLOURS.maroon,
       },
     },
     '& .MuiInputLabel-root.Mui-focused': {
-      color: MCMASTER_COLORS.maroon,
+      color: MCMASTER_COLOURS.maroon,
     },
   };
 
@@ -131,8 +131,8 @@ const CreateSeasonForm = (props) => {
                 sx={{
                   ...textFieldStyles,
                   '& .MuiInputBase-input.Mui-disabled': {
-                    WebkitTextFillColor: MCMASTER_COLORS.grey,
-                    backgroundColor: MCMASTER_COLORS.lightGrey,
+                    WebkitTextFillColor: MCMASTER_COLOURS.grey,
+                    backgroundColor: MCMASTER_COLOURS.lightGrey,
                   }
                 }}
               />
@@ -148,12 +148,12 @@ const CreateSeasonForm = (props) => {
               sx={{
                 mt: 2,
                 py: 1.5,
-                backgroundColor: MCMASTER_COLORS.maroon,
+                backgroundColor: MCMASTER_COLOURS.maroon,
                 '&:hover': {
                   backgroundColor: '#5C002E',
                 },
                 '&.Mui-disabled': {
-                  backgroundColor: MCMASTER_COLORS.grey,
+                  backgroundColor: MCMASTER_COLOURS.grey,
                   color: 'white',
                 },
               }}
@@ -177,7 +177,7 @@ const CreateSeasonForm = (props) => {
           sx={{ 
             width: '100%',
             ...(notification.severity === 'success' && {
-              backgroundColor: MCMASTER_COLORS.maroon,
+              backgroundColor: MCMASTER_COLOURS.maroon,
             })
           }}
         >

--- a/src/frontend/src/components/manage/CreateSeasonForm.jsx
+++ b/src/frontend/src/components/manage/CreateSeasonForm.jsx
@@ -2,6 +2,14 @@ import React, { useState } from "react";
 import { Paper, Button, TextField, Snackbar, Alert, Grid } from "@mui/material";
 import { createSeason, getAllSeasons } from "../../api/season";
 
+// McMaster colors
+const MCMASTER_COLORS = {
+  maroon: '#7A003C',
+  grey: '#5E6A71',
+  gold: '#FDBF57',
+  lightGrey: '#F5F5F5',
+};
+
 const CreateSeasonForm = (props) => {
   const [seasonName, setSeasonName] = useState("");
   const [startDate, setStartDate] = useState("");
@@ -14,18 +22,18 @@ const CreateSeasonForm = (props) => {
 
   // Function to calculate end date (17 weeks after start date)
   const calculateEndDate = (startDate) => {
-    if (!startDate) return ""; // Return empty if no start date is selected
+    if (!startDate) return "";
     const start = new Date(startDate);
     const end = new Date(start);
-    end.setDate(start.getDate() + 17 * 7); // Add 17 weeks
-    return end.toISOString().split("T")[0]; // Format as YYYY-MM-DD
+    end.setDate(start.getDate() + 17 * 7);
+    return end.toISOString().split("T")[0];
   };
 
   // Handle start date change
   const handleStartDateChange = (e) => {
     const selectedStartDate = e.target.value;
     setStartDate(selectedStartDate);
-    setEndDate(calculateEndDate(selectedStartDate)); // Auto-set end date
+    setEndDate(calculateEndDate(selectedStartDate));
   };
 
   const handleCreateSeason = async () => {
@@ -38,6 +46,11 @@ const CreateSeasonForm = (props) => {
       });
       const data = await getAllSeasons();
       props.setSeasons(data.seasons);
+      
+      // Clear form
+      setSeasonName("");
+      setStartDate("");
+      setEndDate("");
     } catch (err) {
       console.log(err);
       setNotification({
@@ -48,39 +61,64 @@ const CreateSeasonForm = (props) => {
     }
   };
 
+  const textFieldStyles = {
+    '& .MuiOutlinedInput-root': {
+      '&:hover fieldset': {
+        borderColor: MCMASTER_COLORS.maroon,
+      },
+      '&.Mui-focused fieldset': {
+        borderColor: MCMASTER_COLORS.maroon,
+      },
+    },
+    '& .MuiInputLabel-root.Mui-focused': {
+      color: MCMASTER_COLORS.maroon,
+    },
+  };
+
   return (
     <>
-      <Paper sx={{ p: 2, mb: 4 }}>
-        <Grid container spacing={2} alignItems="center">
-          {/* Input Fields Row (Season Name, Start Date, End Date) */}
-          <Grid container item spacing={2}>
-            <Grid item xs={4}>
+      <Paper 
+        sx={{ 
+          p: 3, 
+          mb: 4,
+          boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+          border: '1px solid rgba(0,0,0,0.1)',
+          borderRadius: '8px'
+        }}
+      >
+        <Grid container spacing={3} alignItems="center">
+          <Grid container item spacing={3}>
+            <Grid item xs={12} md={4}>
               <TextField
                 label="Season Name"
                 type="text"
                 fullWidth
+                required
                 InputLabelProps={{
                   shrink: true,
                 }}
                 value={seasonName}
                 onChange={(e) => setSeasonName(e.target.value)}
+                sx={textFieldStyles}
               />
             </Grid>
 
-            <Grid item xs={4}>
+            <Grid item xs={12} md={4}>
               <TextField
                 label="Start Date"
                 type="date"
                 fullWidth
+                required
                 InputLabelProps={{
                   shrink: true,
                 }}
                 value={startDate}
                 onChange={handleStartDateChange}
+                sx={textFieldStyles}
               />
             </Grid>
 
-            <Grid item xs={4}>
+            <Grid item xs={12} md={4}>
               <TextField
                 label="End Date"
                 type="date"
@@ -89,32 +127,59 @@ const CreateSeasonForm = (props) => {
                   shrink: true,
                 }}
                 value={endDate}
-                disabled // Lock the end date field
+                disabled
+                sx={{
+                  ...textFieldStyles,
+                  '& .MuiInputBase-input.Mui-disabled': {
+                    WebkitTextFillColor: MCMASTER_COLORS.grey,
+                    backgroundColor: MCMASTER_COLORS.lightGrey,
+                  }
+                }}
               />
             </Grid>
           </Grid>
 
-          {/* Button Row (Separate Row Below) */}
           <Grid item xs={12}>
             <Button
               variant="contained"
               fullWidth
-              sx={{ backgroundColor: "#7A003C" }}
               onClick={handleCreateSeason}
+              disabled={!seasonName || !startDate}
+              sx={{
+                mt: 2,
+                py: 1.5,
+                backgroundColor: MCMASTER_COLORS.maroon,
+                '&:hover': {
+                  backgroundColor: '#5C002E',
+                },
+                '&.Mui-disabled': {
+                  backgroundColor: MCMASTER_COLORS.grey,
+                  color: 'white',
+                },
+              }}
             >
               Create New Season
             </Button>
           </Grid>
         </Grid>
       </Paper>
+      
       <Snackbar
         open={notification.open}
         autoHideDuration={6000}
         onClose={() => setNotification({ ...notification, open: false })}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
       >
         <Alert
           onClose={() => setNotification({ ...notification, open: false })}
           severity={notification.severity}
+          variant="filled"
+          sx={{ 
+            width: '100%',
+            ...(notification.severity === 'success' && {
+              backgroundColor: MCMASTER_COLORS.maroon,
+            })
+          }}
         >
           {notification.message}
         </Alert>

--- a/src/frontend/src/views/AnnouncementsPage.jsx
+++ b/src/frontend/src/views/AnnouncementsPage.jsx
@@ -8,8 +8,8 @@ import EditIcon from "@mui/icons-material/Edit";
 import { useAuth } from "../hooks/AuthProvider";
 import { getPlayerById } from "../api/player";
 
-// McMaster colors
-const MCMASTER_COLORS = {
+// McMaster colours - AI Generated
+const MCMASTER_COLOURS = {
   maroon: '#7A003C',
   grey: '#5E6A71',
   gold: '#FDBF57',
@@ -64,7 +64,7 @@ export default function AnnouncementPage() {
   return (
     <Box 
       sx={{ 
-        bgcolor: MCMASTER_COLORS.lightGrey, 
+        bgcolor: MCMASTER_COLOURS.lightGrey, 
         minHeight: "100vh",
         height: '100%',
         position: 'fixed',
@@ -87,7 +87,7 @@ export default function AnnouncementPage() {
                   variant="contained"
                   sx={{ 
                     borderRadius: 2, 
-                    backgroundColor: MCMASTER_COLORS.maroon, 
+                    backgroundColor: MCMASTER_COLOURS.maroon, 
                     "&:hover": { 
                       backgroundColor: '#5A002C'
                     },
@@ -120,7 +120,7 @@ export default function AnnouncementPage() {
                   left: 0,
                   right: 0,
                   height: '4px',
-                  background: `linear-gradient(to right, ${MCMASTER_COLORS.maroon}, ${MCMASTER_COLORS.gold})`,
+                  background: `linear-gradient(to right, ${MCMASTER_COLOURS.maroon}, ${MCMASTER_COLOURS.gold})`,
                   borderRadius: '2px 2px 0 0'
                 }
               }}
@@ -129,7 +129,7 @@ export default function AnnouncementPage() {
               <Box 
                 sx={{ 
                   display: 'inline-block',
-                  bgcolor: MCMASTER_COLORS.maroon,
+                  bgcolor: MCMASTER_COLOURS.maroon,
                   color: 'white',
                   px: 2,
                   py: 0.5,
@@ -158,7 +158,7 @@ export default function AnnouncementPage() {
                     display: 'block',
                     width: '80px',
                     height: '4px',
-                    bgcolor: MCMASTER_COLORS.gold,
+                    bgcolor: MCMASTER_COLOURS.gold,
                     mx: 'auto',
                     mt: 3,
                     borderRadius: '2px'
@@ -174,7 +174,7 @@ export default function AnnouncementPage() {
                 justifyContent: 'center',
                 gap: 1,
                 mb: 4,
-                color: MCMASTER_COLORS.grey,
+                color: MCMASTER_COLOURS.grey,
                 '& svg': { fontSize: '1rem' }
               }}>
                 <Typography 
@@ -202,7 +202,7 @@ export default function AnnouncementPage() {
                     mb: 2.5
                   },
                   '& strong': {
-                    color: MCMASTER_COLORS.maroon,
+                    color: MCMASTER_COLOURS.maroon,
                     fontWeight: 600
                   }
                 }}
@@ -217,13 +217,13 @@ export default function AnnouncementPage() {
                   justifyContent: "flex-end", 
                   mt: 4,
                   pt: 3,
-                  borderTop: `1px solid ${MCMASTER_COLORS.lightGrey}`
+                  borderTop: `1px solid ${MCMASTER_COLOURS.lightGrey}`
                 }}>
                   <Button
                     variant="contained"
                     sx={{
                       borderRadius: 2,
-                      backgroundColor: MCMASTER_COLORS.maroon,
+                      backgroundColor: MCMASTER_COLOURS.maroon,
                       "&:hover": { 
                         backgroundColor: '#5A002C'
                       }
@@ -249,7 +249,7 @@ export default function AnnouncementPage() {
               left: 0,
               right: 0,
               height: '4px',
-              background: `linear-gradient(to right, ${MCMASTER_COLORS.gold}, ${MCMASTER_COLORS.maroon})`,
+              background: `linear-gradient(to right, ${MCMASTER_COLOURS.gold}, ${MCMASTER_COLOURS.maroon})`,
             }
           }}>
             <PastAnnouncementsSection

--- a/src/frontend/src/views/AnnouncementsPage.jsx
+++ b/src/frontend/src/views/AnnouncementsPage.jsx
@@ -120,6 +120,7 @@ export default function AnnouncementPage() {
                   left: 0,
                   right: 0,
                   height: '4px',
+                  // AI Generated - Ombre bar styling and gradient effects
                   background: `linear-gradient(to right, ${MCMASTER_COLOURS.maroon}, ${MCMASTER_COLOURS.gold})`,
                   borderRadius: '2px 2px 0 0'
                 }
@@ -249,6 +250,7 @@ export default function AnnouncementPage() {
               left: 0,
               right: 0,
               height: '4px',
+              // AI Generated - Ombre bar styling and gradient effects
               background: `linear-gradient(to right, ${MCMASTER_COLOURS.gold}, ${MCMASTER_COLOURS.maroon})`,
             }
           }}>

--- a/src/frontend/src/views/AnnouncementsPage.jsx
+++ b/src/frontend/src/views/AnnouncementsPage.jsx
@@ -8,6 +8,14 @@ import EditIcon from "@mui/icons-material/Edit";
 import { useAuth } from "../hooks/AuthProvider";
 import { getPlayerById } from "../api/player";
 
+// McMaster colors
+const MCMASTER_COLORS = {
+  maroon: '#7A003C',
+  grey: '#5E6A71',
+  gold: '#FDBF57',
+  lightGrey: '#F5F5F5',
+};
+
 export default function AnnouncementPage() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -49,13 +57,23 @@ export default function AnnouncementPage() {
   const userRole = player?.role || "player"; // Default role if undefined
 
   // to exclude the selected announcement from past announcements
-  // (if user has selected READ MORE from past announcement list)
   const pastAnnouncements = announcements.filter(
     (announcement) => announcement._id !== selectedAnnouncement._id
   );
   
   return (
-    <Box sx={{ bgcolor: "background.default", minHeight: "100vh", display: "flex", flexDirection: "column" }}>
+    <Box 
+      sx={{ 
+        bgcolor: MCMASTER_COLORS.lightGrey, 
+        minHeight: "100vh",
+        height: '100%',
+        position: 'fixed',
+        width: '100%',
+        overflowY: 'auto',
+        display: "flex", 
+        flexDirection: "column" 
+      }}
+    >
       <NavBar />
       {!selectedAnnouncement || announcements.length === 0 ? (
         console.log('No announcements fetched')
@@ -67,7 +85,15 @@ export default function AnnouncementPage() {
               <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 4 }}>
                 <Button
                   variant="contained"
-                  sx={{ borderRadius: 2, backgroundColor: "#7A003C", "&:hover": { backgroundColor: "#59002B" } }}
+                  sx={{ 
+                    borderRadius: 2, 
+                    backgroundColor: MCMASTER_COLORS.maroon, 
+                    "&:hover": { 
+                      backgroundColor: '#5A002C'
+                    },
+                    px: 3,
+                    py: 1
+                  }}
                   onClick={() => navigate("/announcements/create")}
                 >
                   Create New Announcement
@@ -76,38 +102,131 @@ export default function AnnouncementPage() {
             )}
 
             {/* Main Announcement */}
-            <Box sx={{ py: 2 }}>
+            <Box 
+              sx={{ 
+                position: 'relative',
+                py: 4,
+                px: { xs: 3, md: 6 },
+                bgcolor: 'white',
+                borderRadius: 2,
+                boxShadow: '0 4px 20px rgba(0,0,0,0.08)',
+                mb: 4,
+                maxWidth: '850px',
+                mx: 'auto',
+                '&::before': {
+                  content: '""',
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  height: '4px',
+                  background: `linear-gradient(to right, ${MCMASTER_COLORS.maroon}, ${MCMASTER_COLORS.gold})`,
+                  borderRadius: '2px 2px 0 0'
+                }
+              }}
+            >
+              {/* Category Tag */}
+              <Box 
+                sx={{ 
+                  display: 'inline-block',
+                  bgcolor: MCMASTER_COLORS.maroon,
+                  color: 'white',
+                  px: 2,
+                  py: 0.5,
+                  borderRadius: 1,
+                  mb: 3,
+                  fontSize: '0.875rem',
+                  fontWeight: 500
+                }}
+              >
+                Important Update
+              </Box>
+
               <Typography
                 variant="h3"
                 align="center"
                 gutterBottom
                 sx={{
-                  fontSize: { xs: "3rem", md: "4rem" },
+                  fontSize: { xs: "2.25rem", md: "3rem" },
                   fontWeight: 900,
+                  color: 'black',
+                  mb: 3,
+                  letterSpacing: '-0.02em',
+                  position: 'relative',
+                  '&::after': {
+                    content: '""',
+                    display: 'block',
+                    width: '80px',
+                    height: '4px',
+                    bgcolor: MCMASTER_COLORS.gold,
+                    mx: 'auto',
+                    mt: 3,
+                    borderRadius: '2px'
+                  }
                 }}
               >
                 {selectedAnnouncement.title}
               </Typography>
-              <Typography align="center" color="text.secondary" gutterBottom>
-                {new Date(selectedAnnouncement.createdAt).toLocaleDateString()}
-              </Typography>
+
+              <Box sx={{ 
+                display: 'flex', 
+                alignItems: 'center', 
+                justifyContent: 'center',
+                gap: 1,
+                mb: 4,
+                color: MCMASTER_COLORS.grey,
+                '& svg': { fontSize: '1rem' }
+              }}>
+                <Typography 
+                  sx={{ 
+                    fontSize: '1rem',
+                    fontStyle: 'italic',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 0.5
+                  }}
+                >
+                  {new Date(selectedAnnouncement.createdAt).toLocaleDateString()}
+                </Typography>
+              </Box>
+
               <Typography
-                paragraph
                 sx={{
-                  fontSize: { md: "1.2rem" },
+                  fontSize: '1.1rem',
+                  lineHeight: 1.8,
+                  color: '#333',
+                  whiteSpace: 'pre-line',
+                  maxWidth: '750px',
+                  mx: 'auto',
+                  '& p': {
+                    mb: 2.5
+                  },
+                  '& strong': {
+                    color: MCMASTER_COLORS.maroon,
+                    fontWeight: 600
+                  }
                 }}
               >
-                {selectedAnnouncement.content}</Typography>
+                {selectedAnnouncement.content}
+              </Typography>
 
               {/* Edit Button for Main Announcement */}
               {userRole === "commissioner" && (
-                <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 2 }}>
+                <Box sx={{ 
+                  display: "flex", 
+                  justifyContent: "flex-end", 
+                  mt: 4,
+                  pt: 3,
+                  borderTop: `1px solid ${MCMASTER_COLORS.lightGrey}`
+                }}>
                   <Button
                     variant="contained"
                     sx={{
                       borderRadius: 2,
-                      backgroundColor: "#7A003C", "&:hover": 
-                      { backgroundColor: "#59002B" }
+                      backgroundColor: MCMASTER_COLORS.maroon,
+                      "&:hover": { 
+                        backgroundColor: '#5A002C'
+                      }
                     }}
                     onClick={() => navigate(`/announcements/edit/${selectedAnnouncement._id}`)}
                     startIcon={<EditIcon />}
@@ -119,12 +238,26 @@ export default function AnnouncementPage() {
             </Box>
           </Container>
 
-          {/* Past Announcements Section */}
-          <PastAnnouncementsSection
-            pastAnnouncements={pastAnnouncements}
-            userRole={userRole}
-            onReadMore={setSelectedAnnouncement} // Pass function to update the main announcement
-          />
+          {/* Past Announcements Section with updated styling */}
+          <Box sx={{ 
+            bgcolor: '#495965',
+            position: 'relative',
+            '&::before': {
+              content: '""',
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              height: '4px',
+              background: `linear-gradient(to right, ${MCMASTER_COLORS.gold}, ${MCMASTER_COLORS.maroon})`,
+            }
+          }}>
+            <PastAnnouncementsSection
+              pastAnnouncements={pastAnnouncements}
+              userRole={userRole}
+              onReadMore={setSelectedAnnouncement}
+            />
+          </Box>
         </>
       )}
     </Box>

--- a/src/frontend/src/views/CreateAnnouncementsPage.jsx
+++ b/src/frontend/src/views/CreateAnnouncementsPage.jsx
@@ -5,6 +5,14 @@ import NavBar from "../components/NavBar";
 import AnnouncementForm from "../components/AnnouncementForm";
 import { createAnnouncement } from "../api/announcements";
 
+// McMaster colors
+const MCMASTER_COLORS = {
+  maroon: '#7A003C',
+  grey: '#5E6A71',
+  gold: '#FDBF57',
+  lightGrey: '#F5F5F5',
+};
+
 export default function CreateAnnouncementPage() {
   const navigate = useNavigate();
 
@@ -18,13 +26,47 @@ export default function CreateAnnouncementPage() {
   };
 
   return (
-    <Box sx={{ bgcolor: "background.default", minHeight: "100vh", display: "flex", flexDirection: "column" }}>
+    <Box 
+      sx={{ 
+        bgcolor: MCMASTER_COLORS.lightGrey, 
+        minHeight: "100vh", 
+        display: "flex", 
+        flexDirection: "column" 
+      }}
+    >
       <NavBar />
       <Container
         maxWidth="lg"
-        sx={{ mt: 4, flexGrow: 1, display: "flex", flexDirection: "column", alignItems: "center" }}
+        sx={{ 
+          py: { xs: 4, md: 6 }, 
+          flexGrow: 1, 
+          display: "flex", 
+          flexDirection: "column", 
+          alignItems: "center" 
+        }}
       >
-        <Typography variant="h4" align="center" gutterBottom sx={{ fontWeight: "bold", mb: 4 }}>
+        <Typography 
+          variant="h4" 
+          align="center" 
+          gutterBottom 
+          sx={{ 
+            fontWeight: 900,
+            color: 'black',
+            mb: { xs: 3, md: 4 },
+            fontSize: { xs: '2.25rem', md: '2.5rem' },
+            position: 'relative',
+            '&::after': {
+              content: '""',
+              display: 'block',
+              width: '80px',
+              height: '4px',
+              bgcolor: MCMASTER_COLORS.gold,
+              mx: 'auto',
+              mt: 2,
+              borderRadius: '2px'
+            }
+          }}
+        >
           Create New Announcement
         </Typography>
         <AnnouncementForm onSubmit={handleCreate} />

--- a/src/frontend/src/views/CreateAnnouncementsPage.jsx
+++ b/src/frontend/src/views/CreateAnnouncementsPage.jsx
@@ -5,8 +5,8 @@ import NavBar from "../components/NavBar";
 import AnnouncementForm from "../components/AnnouncementForm";
 import { createAnnouncement } from "../api/announcements";
 
-// McMaster colors
-const MCMASTER_COLORS = {
+// McMaster colours - AI Generated
+const MCMASTER_COLOURS = {
   maroon: '#7A003C',
   grey: '#5E6A71',
   gold: '#FDBF57',
@@ -28,7 +28,7 @@ export default function CreateAnnouncementPage() {
   return (
     <Box 
       sx={{ 
-        bgcolor: MCMASTER_COLORS.lightGrey, 
+        bgcolor: MCMASTER_COLOURS.lightGrey, 
         minHeight: "100vh", 
         display: "flex", 
         flexDirection: "column" 
@@ -60,7 +60,7 @@ export default function CreateAnnouncementPage() {
               display: 'block',
               width: '80px',
               height: '4px',
-              bgcolor: MCMASTER_COLORS.gold,
+              bgcolor: MCMASTER_COLOURS.gold,
               mx: 'auto',
               mt: 2,
               borderRadius: '2px'

--- a/src/frontend/src/views/EditAnnouncementsPage.jsx
+++ b/src/frontend/src/views/EditAnnouncementsPage.jsx
@@ -13,6 +13,7 @@ const MCMASTER_COLOURS = {
   lightGrey: '#F5F5F5',
 };
 
+// AI Generated - Ombre bar styling and gradient effects
 export default function EditAnnouncementPage() {
   const { id } = useParams();
   const navigate = useNavigate();

--- a/src/frontend/src/views/EditAnnouncementsPage.jsx
+++ b/src/frontend/src/views/EditAnnouncementsPage.jsx
@@ -5,8 +5,8 @@ import NavBar from "../components/NavBar";
 import AnnouncementForm from "../components/AnnouncementForm";
 import { getAnnouncementById, editAnnouncement, deleteAnnouncement } from "../api/announcements";
 
-// McMaster colors
-const MCMASTER_COLORS = {
+// McMaster colours - AI Generated
+const MCMASTER_COLOURS = {
   maroon: '#7A003C',
   grey: '#5E6A71',
   gold: '#FDBF57',
@@ -60,7 +60,7 @@ export default function EditAnnouncementPage() {
   return (
     <Box 
       sx={{ 
-        bgcolor: MCMASTER_COLORS.lightGrey, 
+        bgcolor: MCMASTER_COLOURS.lightGrey, 
         minHeight: "100vh", 
         display: "flex", 
         flexDirection: "column" 
@@ -92,7 +92,7 @@ export default function EditAnnouncementPage() {
               display: 'block',
               width: '80px',
               height: '4px',
-              bgcolor: MCMASTER_COLORS.gold,
+              bgcolor: MCMASTER_COLOURS.gold,
               mx: 'auto',
               mt: 2,
               borderRadius: '2px'
@@ -104,7 +104,7 @@ export default function EditAnnouncementPage() {
 
         {loading ? (
           <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}>
-            <CircularProgress sx={{ color: MCMASTER_COLORS.maroon }} />
+            <CircularProgress sx={{ color: MCMASTER_COLOURS.maroon }} />
           </Box>
         ) : error ? (
           <Typography 
@@ -133,7 +133,7 @@ export default function EditAnnouncementPage() {
             align="center" 
             sx={{ 
               mt: 4, 
-              color: MCMASTER_COLORS.grey,
+              color: MCMASTER_COLOURS.grey,
               bgcolor: 'white',
               p: 3,
               borderRadius: 1,

--- a/src/frontend/src/views/EditAnnouncementsPage.jsx
+++ b/src/frontend/src/views/EditAnnouncementsPage.jsx
@@ -1,22 +1,35 @@
 import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Container, Typography, Box } from "@mui/material";
+import { Container, Typography, Box, CircularProgress } from "@mui/material";
 import NavBar from "../components/NavBar";
 import AnnouncementForm from "../components/AnnouncementForm";
 import { getAnnouncementById, editAnnouncement, deleteAnnouncement } from "../api/announcements";
+
+// McMaster colors
+const MCMASTER_COLORS = {
+  maroon: '#7A003C',
+  grey: '#5E6A71',
+  gold: '#FDBF57',
+  lightGrey: '#F5F5F5',
+};
 
 export default function EditAnnouncementPage() {
   const { id } = useParams();
   const navigate = useNavigate();
   const [announcement, setAnnouncement] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     const fetchAnnouncement = async () => {
       try {
         const response = await getAnnouncementById(id);
-        setAnnouncement(response.announcement); // Ensure we're accessing the correct key
+        setAnnouncement(response.announcement);
       } catch (error) {
         console.error("Error fetching announcement:", error);
+        setError("Failed to load announcement");
+      } finally {
+        setLoading(false);
       }
     };
     fetchAnnouncement();
@@ -25,9 +38,10 @@ export default function EditAnnouncementPage() {
   const handleEdit = async ({ title, content }) => {
     try {
       await editAnnouncement(id, title, content);
-      navigate("/announcements"); // Redirect after editing
+      navigate("/announcements");
     } catch (error) {
       console.error("Error editing announcement:", error);
+      setError("Failed to save changes");
     }
   };
 
@@ -35,38 +49,100 @@ export default function EditAnnouncementPage() {
     if (window.confirm("Are you sure you want to delete this announcement?")) {
       try {
         await deleteAnnouncement(id);
-        navigate("/announcements"); // Redirect after deletion
+        navigate("/announcements");
       } catch (error) {
         console.error("Error deleting announcement:", error);
+        setError("Failed to delete announcement");
       }
     }
   };
 
-  if (announcement === null) {
-    return <Typography align="center" sx={{ mt: 4 }}>Fetching announcement details...</Typography>;
-  }
-  
-  if (!announcement) {
-    return <Typography align="center" sx={{ mt: 4, color: "red" }}>Error: Announcement not found.</Typography>;
-  }  
-
   return (
-    <Box sx={{ bgcolor: "background.default", minHeight: "100vh", display: "flex", flexDirection: "column" }}>
+    <Box 
+      sx={{ 
+        bgcolor: MCMASTER_COLORS.lightGrey, 
+        minHeight: "100vh", 
+        display: "flex", 
+        flexDirection: "column" 
+      }}
+    >
       <NavBar />
       <Container
         maxWidth="lg"
-        sx={{ mt: 4, flexGrow: 1, display: "flex", flexDirection: "column", alignItems: "center" }}
+        sx={{ 
+          py: { xs: 4, md: 6 }, 
+          flexGrow: 1, 
+          display: "flex", 
+          flexDirection: "column", 
+          alignItems: "center" 
+        }}
       >
-        <Typography variant="h4" align="center" gutterBottom sx={{ fontWeight: "bold", mb: 4 }}>
+        <Typography 
+          variant="h4" 
+          align="center" 
+          gutterBottom 
+          sx={{ 
+            fontWeight: 900,
+            color: 'black',
+            mb: { xs: 3, md: 4 },
+            fontSize: { xs: '2.25rem', md: '2.5rem' },
+            position: 'relative',
+            '&::after': {
+              content: '""',
+              display: 'block',
+              width: '80px',
+              height: '4px',
+              bgcolor: MCMASTER_COLORS.gold,
+              mx: 'auto',
+              mt: 2,
+              borderRadius: '2px'
+            }
+          }}
+        >
           Edit Announcement
         </Typography>
-        <AnnouncementForm
-          onSubmit={handleEdit}
-          onDelete={handleDelete}
-          initialTitle={announcement.title}
-          initialContent={announcement.content}
-          isEdit
-        />
+
+        {loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}>
+            <CircularProgress sx={{ color: MCMASTER_COLORS.maroon }} />
+          </Box>
+        ) : error ? (
+          <Typography 
+            align="center" 
+            sx={{ 
+              mt: 4, 
+              color: '#d32f2f',
+              bgcolor: 'white',
+              p: 3,
+              borderRadius: 1,
+              boxShadow: 1
+            }}
+          >
+            {error}
+          </Typography>
+        ) : announcement ? (
+          <AnnouncementForm
+            onSubmit={handleEdit}
+            onDelete={handleDelete}
+            initialTitle={announcement.title}
+            initialContent={announcement.content}
+            isEdit
+          />
+        ) : (
+          <Typography 
+            align="center" 
+            sx={{ 
+              mt: 4, 
+              color: MCMASTER_COLORS.grey,
+              bgcolor: 'white',
+              p: 3,
+              borderRadius: 1,
+              boxShadow: 1
+            }}
+          >
+            Announcement not found.
+          </Typography>
+        )}
       </Container>
     </Box>
   );

--- a/src/frontend/src/views/HomePage.jsx
+++ b/src/frontend/src/views/HomePage.jsx
@@ -11,6 +11,7 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
+  Divider,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
@@ -28,6 +29,14 @@ import { getPlayerById } from "../api/player";
 import { useAuth } from "../hooks/AuthProvider";
 import NotificationsRow from "../components/NotificationsRow";
 import NoDataCard from "../components/NoDataCard";
+
+// McMaster colours - AI generated
+const MCMASTER_COLOURS = {
+  maroon: '#7A003C',
+  grey: '#5E6A71',
+  gold: '#FDBF57',
+  lightGrey: '#F5F5F5',
+};
 
 const StyledCard = styled(Card)(({ theme }) => ({
   height: "300px",
@@ -109,95 +118,173 @@ export default function HomePage() {
   return (
     <>
       <NavBar />
-      <Box sx={{ bgcolor: "background.default", minHeight: "100vh" }}>
+      <Box sx={{ bgcolor: "#f5f5f5", minHeight: "100vh" }}>
         {loading && <LoadingOverlay loading={loading} />}
         {/* Hero Section */}
-        <Container maxWidth="lg" sx={{ pt: 8, pb: 4, width: "100%" }}>
-          <Grid container spacing={2} alignItems="center">
-            {/* Title and Welcome Message */}
-            <Grid item xs={8} md={8}>
-              <Typography
-                variant="h1"
-                sx={{
-                  fontSize: { xs: "3rem", md: "4rem" },
-                  fontWeight: 900,
-                  color: "text.primary",
-                  mb: 1,
-                }}
-              >
-                McMaster GSA
-              </Typography>
-              <Typography
-                variant="body1"
-                sx={{ color: "text.secondary", fontSize: "1.1rem" }}
-              >
-                Welcome to the McMaster Graduate Students Association Softball
-                League!
-              </Typography>
-            </Grid>
+        <Box sx={{ bgcolor: 'white', pb: 8, borderBottom: '1px solid rgba(0,0,0,0.1)' }}>
+          <Container maxWidth="lg" sx={{ pt: 10, width: "100%" }}>
+            <Grid container spacing={2} alignItems="center">
+              {/* Title and Welcome Message */}
+              <Grid item xs={8} md={8}>
+                <Typography
+                  variant="h1"
+                  sx={{
+                    fontSize: { xs: "3.5rem", md: "5rem" },
+                    fontWeight: 900,
+                    color: "black",
+                    mb: 2,
+                    lineHeight: 1.1,
+                  }}
+                >
+                  McMaster GSA
+                </Typography>
+                <Typography
+                  variant="h6"
+                  sx={{ 
+                    color: MCMASTER_COLOURS.grey, 
+                    fontSize: "1.2rem",
+                    maxWidth: "600px" 
+                  }}
+                >
+                  Welcome to the McMaster Graduate Students Association Softball League!
+                </Typography>
+              </Grid>
 
-            {/* Logo */}
-            <Grid
-              item
-              xs={4}
-              md={4}
-              sx={{
-                display: "flex",
-                justifyContent: "flex-end",
-                alignItems: "center",
-              }}
-            >
-              <img
-                src={GSALogo}
-                alt="GSA Logo"
-                style={{
-                  width: "300px",
-                  height: "auto",
-                  objectFit: "contain",
-                  paddingBottom: "3px",
+              {/* Logo */}
+              <Grid
+                item
+                xs={4}
+                md={4}
+                sx={{
+                  display: "flex",
+                  justifyContent: "flex-end",
+                  alignItems: "center",
                 }}
-              />
+              >
+                <img
+                  src={GSALogo}
+                  alt="GSA Logo"
+                  style={{
+                    width: "300px",
+                    height: "auto",
+                    objectFit: "contain",
+                    paddingBottom: "55px",
+                  }}
+                />
+              </Grid>
             </Grid>
-          </Grid>
-        </Container>
-        <Container maxWidth="lg" sx={{ pt: 2 }}>
-          {/* Seasons Section */}
-          <Typography
-            variant="h3"
+          </Container>
+        </Box>
+
+        {/* Main Content */}
+        <Container maxWidth="lg" sx={{ py: 6 }}>
+          <Box
             sx={{
-              fontSize: { xs: "2rem", md: "3rem" },
-              fontWeight: 700,
-              mb: 2,
+              bgcolor: 'white',
+              borderRadius: 2,
+              boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+              border: '1px solid rgba(0,0,0,0.1)',
+              p: 4,
             }}
           >
-            Seasons
-          </Typography>
-          <Accordion defaultExpanded={true}>
-            <AccordionSummary
-              expandIcon={<ArrowDropDownIcon />}
-              id="upcoming-header"
+            {/* Seasons Section */}
+            <Typography
+              variant="h3"
+              sx={{
+                fontSize: { xs: "2.5rem", md: "3rem" },
+                fontWeight: 700,
+                mb: 3,
+                color: "black",
+                fontFamily: "inherit",
+              }}
             >
-              <Typography component="span">Upcoming Seasons</Typography>
-            </AccordionSummary>
-            <AccordionDetails>
-              <SeasonsCard seasons={upcomingSeasons} status="Upcoming" />
-            </AccordionDetails>
-          </Accordion>
-          <Accordion>
-            <AccordionSummary
-              expandIcon={<ArrowDropDownIcon />}
-              id="ongoing-header"
+              Seasons
+            </Typography>
+            <Accordion 
+              defaultExpanded={true}
+              sx={{
+                '&.MuiAccordion-root': {
+                  boxShadow: 'none',
+                  border: '1px solid rgba(0,0,0,0.1)',
+                  borderRadius: '8px',
+                  mb: 2,
+                  '&:before': {
+                    display: 'none',
+                  },
+                },
+                '& .MuiAccordionSummary-root': {
+                  minHeight: 56,
+                  backgroundColor: MCMASTER_COLOURS.lightGrey,
+                  borderRadius: '8px 8px 0 0',
+                  '&.Mui-expanded': {
+                    minHeight: 56,
+                    backgroundColor: MCMASTER_COLOURS.lightGrey,
+                  },
+                },
+                '& .MuiAccordionSummary-content': {
+                  margin: '12px 0',
+                  '&.Mui-expanded': {
+                    margin: '12px 0',
+                  },
+                },
+              }}
             >
-              <Typography component="span">Ongoing Seasons</Typography>
-            </AccordionSummary>
-            <AccordionDetails>
-              <SeasonsCard seasons={ongoingSeasons} status="Ongoing" />
-            </AccordionDetails>
-          </Accordion>
-        </Container>
-        <Container maxWidth="lg" sx={{ pt: 10 }}>
-          <Box sx={{ py: 2 }}>
-            <Container maxWidth="lg">
+              <AccordionSummary
+                expandIcon={<ArrowDropDownIcon />}
+                id="upcoming-header"
+              >
+                <Typography variant="h6" component="span" sx={{ fontWeight: 600, color: MCMASTER_COLOURS.maroon }}>
+                  Upcoming Seasons
+                </Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <SeasonsCard seasons={upcomingSeasons} status="Upcoming" />
+              </AccordionDetails>
+            </Accordion>
+            <Accordion
+              sx={{
+                '&.MuiAccordion-root': {
+                  boxShadow: 'none',
+                  border: '1px solid rgba(0,0,0,0.1)',
+                  borderRadius: '8px',
+                  '&:before': {
+                    display: 'none',
+                  },
+                },
+                '& .MuiAccordionSummary-root': {
+                  minHeight: 56,
+                  backgroundColor: MCMASTER_COLOURS.lightGrey,
+                  borderRadius: '8px 8px 0 0',
+                  '&.Mui-expanded': {
+                    minHeight: 56,
+                    backgroundColor: MCMASTER_COLOURS.lightGrey,
+                  },
+                },
+                '& .MuiAccordionSummary-content': {
+                  margin: '12px 0',
+                  '&.Mui-expanded': {
+                    margin: '12px 0',
+                  },
+                },
+              }}
+            >
+              <AccordionSummary
+                expandIcon={<ArrowDropDownIcon />}
+                id="ongoing-header"
+              >
+                <Typography variant="h6" component="span" sx={{ fontWeight: 600, color: MCMASTER_COLOURS.maroon }}>
+                  Ongoing Seasons
+                </Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <SeasonsCard seasons={ongoingSeasons} status="Ongoing" />
+              </AccordionDetails>
+            </Accordion>
+
+            <Box sx={{ mt: 6, mb: 2 }}>
+              <Divider sx={{ mb: 6 }} />
+              
+              {/* Announcements Section */}
               <Box
                 sx={{
                   display: "flex",
@@ -209,9 +296,10 @@ export default function HomePage() {
                 <Typography
                   variant="h3"
                   sx={{
-                    fontSize: { xs: "2rem", md: "3rem" },
+                    fontSize: { xs: "2.5rem", md: "3rem" },
                     fontWeight: 700,
-                    mb: 2,
+                    color: "black",
+                    fontFamily: "inherit",
                   }}
                 >
                   Announcements
@@ -220,48 +308,69 @@ export default function HomePage() {
 
               <Grid container spacing={4}>
                 {announcements.length === 0 ? (
-                  <Typography>No announcements available.</Typography>
+                  <Grid item xs={12}>
+                    <NoDataCard text="No announcements available." />
+                  </Grid>
                 ) : (
                   announcements.map((announcement) => (
                     <Grid item xs={12} md={4} key={announcement._id}>
-                      <StyledCard>
+                      <Card
+                        sx={{
+                          height: "100%",
+                          display: "flex",
+                          flexDirection: "column",
+                          borderRadius: 2,
+                          boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+                          border: '1px solid rgba(0,0,0,0.1)',
+                          transition: "transform 0.2s ease, box-shadow 0.2s ease",
+                          backgroundColor: MCMASTER_COLOURS.lightGrey,
+                          "&:hover": {
+                            transform: "translateY(-4px)",
+                            boxShadow: '0 8px 24px rgba(0,0,0,0.15)',
+                          },
+                        }}
+                      >
                         <CardContent
                           sx={{
                             flexGrow: 1,
                             display: "flex",
                             flexDirection: "column",
                             justifyContent: "space-between",
+                            p: 3,
                           }}
                         >
-                          <Typography
-                            gutterBottom
-                            variant="h4"
-                            component="h2"
-                            sx={{
-                              fontWeight: 700,
-                            }}
-                          >
-                            {announcement.title}
-                          </Typography>
-                          <Typography
-                            variant="body"
-                            color="text.secondary"
-                            sx={{ mb: 2 }}
-                          >
-                            {announcement.content.length > 100
-                              ? `${announcement.content.substring(0, 100)}...`
-                              : announcement.content}
-                          </Typography>
+                          <Box>
+                            <Typography
+                              gutterBottom
+                              variant="h5"
+                              component="h2"
+                              sx={{
+                                fontWeight: 700,
+                                mb: 2,
+                                color: MCMASTER_COLOURS.maroon,
+                              }}
+                            >
+                              {announcement.title}
+                            </Typography>
+                            <Typography
+                              variant="body2"
+                              color={MCMASTER_COLOURS.grey}
+                              sx={{ mb: 3 }}
+                            >
+                              {announcement.content.length > 100
+                                ? `${announcement.content.substring(0, 100)}...`
+                                : announcement.content}
+                            </Typography>
+                          </Box>
                           <Button
                             variant="contained"
                             sx={{
-                              bgcolor: "common.black",
-                              color: "common.white",
-                              borderRadius: "50px",
+                              backgroundColor: MCMASTER_COLOURS.maroon,
+                              color: 'white',
+                              borderRadius: 2,
                               width: "fit-content",
                               "&:hover": {
-                                bgcolor: "#7A003C",
-                                opacity: 0.9,
+                                backgroundColor: '#5C002E',
                               },
                             }}
                             onClick={() =>
@@ -273,12 +382,12 @@ export default function HomePage() {
                             Read More
                           </Button>
                         </CardContent>
-                      </StyledCard>
+                      </Card>
                     </Grid>
                   ))
                 )}
               </Grid>
-            </Container>
+            </Box>
           </Box>
         </Container>
       </Box>

--- a/src/frontend/src/views/HomePage.jsx
+++ b/src/frontend/src/views/HomePage.jsx
@@ -143,10 +143,10 @@ export default function HomePage() {
                   sx={{ 
                     color: MCMASTER_COLOURS.grey, 
                     fontSize: "1.2rem",
-                    maxWidth: "600px" 
+                    maxWidth: "750px" 
                   }}
                 >
-                  Welcome to the McMaster Graduate Students Association Softball League!
+                  Welcome to the McMaster Graduate Students Association Softball League! 
                 </Typography>
               </Grid>
 

--- a/src/frontend/src/views/HomePage.jsx
+++ b/src/frontend/src/views/HomePage.jsx
@@ -168,7 +168,7 @@ export default function HomePage() {
                     width: "300px",
                     height: "auto",
                     objectFit: "contain",
-                    paddingBottom: "55px",
+                    paddingBottom: "30px",
                   }}
                 />
               </Grid>

--- a/src/frontend/src/views/LeagueManagementPage.jsx
+++ b/src/frontend/src/views/LeagueManagementPage.jsx
@@ -31,8 +31,8 @@ import ScheduleTable from "../components/ScheduleTable";
 import LoadingOverlay from "../components/LoadingOverlay";
 import CommissionerContactInfo from "../components/manage/CommissionerContactInfo";
 
-// McMaster colors
-const MCMASTER_COLORS = {
+// McMaster colours - AI Generated
+const MCMASTER_COLOURS = {
   maroon: '#7A003C',
   grey: '#5E6A71',
   gold: '#FDBF57',
@@ -136,7 +136,7 @@ const LeagueManagementPage = () => {
           fontStyle: italic ? "italic" : "normal",
           fontWeight: bold ? 600 : 400,
           fontSize: size,
-          color: MCMASTER_COLORS.grey,
+          color: MCMASTER_COLOURS.grey,
           mb: 3,
           maxWidth: '800px'
         }}
@@ -147,7 +147,7 @@ const LeagueManagementPage = () => {
   };
 
   return (
-    <Box sx={{ bgcolor: MCMASTER_COLORS.lightGrey, minHeight: '100vh' }}>
+    <Box sx={{ bgcolor: MCMASTER_COLOURS.lightGrey, minHeight: '100vh' }}>
       <NavBar />
       {loading && <LoadingOverlay loading={loading} />}
 
@@ -164,7 +164,7 @@ const LeagueManagementPage = () => {
               display: 'block',
               width: '80px',
               height: '4px',
-              bgcolor: MCMASTER_COLORS.gold,
+              bgcolor: MCMASTER_COLOURS.gold,
               mt: 2,
               borderRadius: '2px'
             }
@@ -194,17 +194,17 @@ const LeagueManagementPage = () => {
                   '& .MuiTab-root': {
                     fontSize: '0.95rem',
                     fontWeight: 500,
-                    color: MCMASTER_COLORS.grey,
+                    color: MCMASTER_COLOURS.grey,
                     '&.Mui-selected': {
-                      color: MCMASTER_COLORS.maroon,
+                      color: MCMASTER_COLOURS.maroon,
                       fontWeight: 600
                     },
                     '&.Mui-disabled': {
-                      color: `${MCMASTER_COLORS.grey}80`,
+                      color: `${MCMASTER_COLOURS.grey}80`,
                     }
                   },
                   '& .MuiTabs-indicator': {
-                    backgroundColor: MCMASTER_COLORS.maroon
+                    backgroundColor: MCMASTER_COLOURS.maroon
                   }
                 }}
               >
@@ -215,7 +215,7 @@ const LeagueManagementPage = () => {
                 <Tab label="Contact Info" value="contacts" disabled={isTabLoading} />
               </TabList>
             </Box>
-            
+
             {/* Loading overlay component - AI generated */}
             <Box sx={{ position: 'relative' }}>
               {isTabLoading && (
@@ -236,7 +236,7 @@ const LeagueManagementPage = () => {
                 >
                   <Typography 
                     sx={{ 
-                      color: MCMASTER_COLORS.maroon,
+                      color: MCMASTER_COLOURS.maroon,
                       fontWeight: 500,
                       display: 'flex',
                       alignItems: 'center',
@@ -256,7 +256,7 @@ const LeagueManagementPage = () => {
                   variant="h6" 
                   sx={{ 
                     mb: 3,
-                    color: MCMASTER_COLORS.maroon,
+                    color: MCMASTER_COLOURS.maroon,
                     fontWeight: 600
                   }}
                 >
@@ -295,7 +295,7 @@ const LeagueManagementPage = () => {
                       <Typography 
                         variant="h6"
                         sx={{ 
-                          color: MCMASTER_COLORS.maroon,
+                          color: MCMASTER_COLOURS.maroon,
                           fontWeight: 600,
                           fontSize: '1.1rem'
                         }}
@@ -305,10 +305,10 @@ const LeagueManagementPage = () => {
                     </AccordionSummary>
                     <AccordionDetails sx={{ p: 3 }}>
                       <Box sx={{ mb: 3 }}>
-                        <Typography sx={{ mb: 1, color: MCMASTER_COLORS.grey }}>
+                        <Typography sx={{ mb: 1, color: MCMASTER_COLOURS.grey }}>
                           <strong>Start Date:</strong> {formatDate(season.startDate)}
                         </Typography>
-                        <Typography sx={{ color: MCMASTER_COLORS.grey }}>
+                        <Typography sx={{ color: MCMASTER_COLOURS.grey }}>
                           <strong>End Date:</strong> {formatDate(season.endDate)}
                         </Typography>
                       </Box>
@@ -351,7 +351,7 @@ const LeagueManagementPage = () => {
                       <Typography 
                         variant="h6"
                         sx={{ 
-                          color: MCMASTER_COLORS.maroon,
+                          color: MCMASTER_COLOURS.maroon,
                           fontWeight: 600,
                           fontSize: '1.1rem'
                         }}
@@ -402,7 +402,7 @@ const LeagueManagementPage = () => {
                       <Typography 
                         variant="h6"
                         sx={{ 
-                          color: MCMASTER_COLORS.maroon,
+                          color: MCMASTER_COLOURS.maroon,
                           fontWeight: 600,
                           fontSize: '1.1rem'
                         }}

--- a/src/frontend/src/views/LeagueManagementPage.jsx
+++ b/src/frontend/src/views/LeagueManagementPage.jsx
@@ -1,5 +1,4 @@
-import React, { useEffect } from "react";
-import { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Typography,
   Container,
@@ -77,19 +76,25 @@ const LeagueManagementPage = () => {
 
     const fetchOngoingSeasons = async () => {
       try {
+        setLoading(true);
         const data = await getOngoingSeasons();
         setOngoingSeasons(data.seasons);
       } catch (err) {
         setError(err.message || "Failed to fetch ongoing seasons");
+      } finally {
+        setLoading(false);
       }
     };
 
     const fetchArchivedSeasons = async () => {
       try {
+        setLoading(true);
         const data = await getArchivedSeasons();
         setArchivedSeasons(data.seasons);
       } catch (err) {
         setError(err.message || "Failed to fetch ongoing seasons");
+      } finally {
+        setLoading(false);
       }
     };
 
@@ -215,7 +220,7 @@ const LeagueManagementPage = () => {
                 <Tab label="Contact Info" value="contacts" disabled={isTabLoading} />
               </TabList>
             </Box>
-
+            
             {/* Loading overlay component - AI generated */}
             <Box sx={{ position: 'relative' }}>
               {isTabLoading && (
@@ -249,10 +254,10 @@ const LeagueManagementPage = () => {
               )}
 
               <TabPanel value="manage" sx={{ p: { xs: 2, md: 3 } }}>
-                <InfoText>
-                  Create new seasons and delete seasons that are no longer needed.
-                </InfoText>
-                <Typography 
+              <InfoText>
+                Create new seasons and delete seasons that are no longer needed.
+              </InfoText>
+              <Typography 
                   variant="h6" 
                   sx={{ 
                     mb: 3,
@@ -260,18 +265,22 @@ const LeagueManagementPage = () => {
                     fontWeight: 600
                   }}
                 >
-                  Create New Season
-                </Typography>
-                <CreateSeasonForm seasons={seasons} setSeasons={setSeasons} />
+                Create New Season
+              </Typography>
+              <CreateSeasonForm seasons={seasons} setSeasons={setSeasons} />
+              {seasons && seasons.length > 0 ? (
                 <SeasonsTable seasons={seasons} setSeasons={setSeasons} />
-              </TabPanel>
-
-              <TabPanel value="upcoming" sx={{ p: { xs: 2, md: 3 } }}>
-                <InfoText>
-                  Manage and launch seasons that are currently open for registration. 
-                  Seasons will automatically launch on the start date.
-                </InfoText>
-                {!!upcomingSeasons && upcomingSeasons.map((season) => (
+              ) : (
+                <Typography>No seasons available</Typography>
+              )}
+            </TabPanel>
+            <TabPanel value="upcoming" sx={{ p: { xs: 2, md: 3 } }}>
+              <InfoText>
+                Manage and launch seasons that are currently open for
+                registration. Seasons will automatically launch on the start date.
+              </InfoText>
+              {upcomingSeasons && upcomingSeasons.length > 0 ? (
+                upcomingSeasons.map((season) => (
                   <Accordion 
                     key={season.id}
                     sx={{
@@ -319,7 +328,10 @@ const LeagueManagementPage = () => {
                       />
                     </AccordionDetails>
                   </Accordion>
-                ))}
+                ))
+              ) : (
+                <Typography>No upcoming seasons</Typography>
+              )}
               </TabPanel>
 
               <TabPanel value="ongoing" sx={{ p: { xs: 2, md: 3 } }}>
@@ -327,9 +339,10 @@ const LeagueManagementPage = () => {
                   Input scores and view the schedules and results of ongoing seasons. 
                   Seasons will be automatically archived after the end date.
                 </InfoText>
-                {!!ongoingSeasons && ongoingSeasons.map((season) => (
+                {ongoingSeasons && ongoingSeasons.length > 0 ? ( 
+                  ongoingSeasons.map((season) => (
                   <Accordion 
-                    key={season.id}
+                    key={season.id} 
                     sx={{
                       mb: 2,
                       boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
@@ -371,15 +384,19 @@ const LeagueManagementPage = () => {
                       </Button>
                     </AccordionDetails>
                   </Accordion>
-                ))}
+                ))
+              ) : (
+                <Typography>No ongoing seasons</Typography>
+              )}
               </TabPanel>
 
               <TabPanel value="archived" sx={{ p: { xs: 2, md: 3 } }}>
                 <InfoText>
                   View schedules and results of past archived seasons.
                 </InfoText>
-                {!!archivedSeasons && archivedSeasons.map((season) => (
-                  <Accordion 
+                {!!archivedSeasons ? 
+                (archivedSeasons.map((season) => (
+                    <Accordion 
                     key={season.id}
                     sx={{
                       mb: 2,
@@ -390,16 +407,16 @@ const LeagueManagementPage = () => {
                       }
                     }}
                   >
-                    <AccordionSummary
-                      expandIcon={<ArrowDropDownIcon />}
-                      sx={{
+                      <AccordionSummary
+                        expandIcon={<ArrowDropDownIcon />}
+                        sx={{
                         backgroundColor: 'rgba(122, 0, 60, 0.03)',
                         '&:hover': {
                           backgroundColor: 'rgba(122, 0, 60, 0.05)',
                         }
                       }}
-                    >
-                      <Typography 
+                      >
+                        <Typography 
                         variant="h6"
                         sx={{ 
                           color: MCMASTER_COLOURS.maroon,
@@ -407,14 +424,17 @@ const LeagueManagementPage = () => {
                           fontSize: '1.1rem'
                         }}
                       >
-                        {season.name}
-                      </Typography>
-                    </AccordionSummary>
-                    <AccordionDetails sx={{ p: 3 }}>
-                      <ScheduleTable schedule={season.schedule} archived />
-                    </AccordionDetails>
-                  </Accordion>
-                ))}
+                          {season.name}
+                        </Typography>
+                      </AccordionSummary>
+                      <AccordionDetails sx={{ p: 3 }}>
+                        <ScheduleTable schedule={season.schedule} archived />
+                      </AccordionDetails>
+                    </Accordion>
+                  ))
+                ) : (
+                  <Typography>No ongoing seasons</Typography>
+              )}
               </TabPanel>
 
               <TabPanel value="contacts" sx={{ p: { xs: 2, md: 3 } }}>

--- a/src/frontend/src/views/LeagueManagementPage.jsx
+++ b/src/frontend/src/views/LeagueManagementPage.jsx
@@ -31,6 +31,14 @@ import ScheduleTable from "../components/ScheduleTable";
 import LoadingOverlay from "../components/LoadingOverlay";
 import CommissionerContactInfo from "../components/manage/CommissionerContactInfo";
 
+// McMaster colors
+const MCMASTER_COLORS = {
+  maroon: '#7A003C',
+  grey: '#5E6A71',
+  gold: '#FDBF57',
+  lightGrey: '#F5F5F5',
+};
+
 const LeagueManagementPage = () => {
   // Season state values
   const [upcomingSeasons, setUpcomingSeasons] = useState(null);
@@ -115,7 +123,7 @@ const LeagueManagementPage = () => {
   const InfoText = ({
     children,
     italic = true,
-    bold = true,
+    bold = false,
     size = "0.875rem",
   }) => {
     return (
@@ -124,9 +132,11 @@ const LeagueManagementPage = () => {
         gutterBottom
         sx={{
           fontStyle: italic ? "italic" : "normal",
-          fontWeight: bold ? "bold" : "normal",
+          fontWeight: bold ? 600 : 400,
           fontSize: size,
-          mb: 2,
+          color: MCMASTER_COLORS.grey,
+          mb: 3,
+          maxWidth: '800px'
         }}
       >
         {children}
@@ -135,18 +145,61 @@ const LeagueManagementPage = () => {
   };
 
   return (
-    <>
+    <Box sx={{ bgcolor: MCMASTER_COLORS.lightGrey, minHeight: '100vh' }}>
       <NavBar />
       {loading && <LoadingOverlay loading={loading} />}
 
-      <Container maxWidth="lg" sx={{ mt: 4 }}>
-        <Typography variant="h5" gutterBottom sx={{ mb: 2 }}>
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        <Typography 
+          variant="h4" 
+          sx={{ 
+            mb: 4,
+            color: 'black',
+            fontWeight: 900,
+            position: 'relative',
+            '&::after': {
+              content: '""',
+              display: 'block',
+              width: '80px',
+              height: '4px',
+              bgcolor: MCMASTER_COLORS.gold,
+              mt: 2,
+              borderRadius: '2px'
+            }
+          }}
+        >
           League Management
         </Typography>
-        <Box>
+
+        <Box sx={{ 
+          bgcolor: 'white', 
+          borderRadius: 2,
+          boxShadow: '0 4px 20px rgba(0,0,0,0.08)',
+          overflow: 'hidden'
+        }}>
           <TabContext value={value}>
-            <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
-              <TabList onChange={handleTabChange}>
+            <Box sx={{ 
+              borderBottom: 1, 
+              borderColor: 'divider',
+              bgcolor: 'white'
+            }}>
+              <TabList 
+                onChange={handleTabChange}
+                sx={{
+                  '& .MuiTab-root': {
+                    fontSize: '0.95rem',
+                    fontWeight: 500,
+                    color: MCMASTER_COLORS.grey,
+                    '&.Mui-selected': {
+                      color: MCMASTER_COLORS.maroon,
+                      fontWeight: 600
+                    }
+                  },
+                  '& .MuiTabs-indicator': {
+                    backgroundColor: MCMASTER_COLORS.maroon
+                  }
+                }}
+              >
                 <Tab label="Manage Seasons" value="manage" />
                 <Tab label="Upcoming Seasons" value="upcoming" />
                 <Tab label="Ongoing Seasons" value="ongoing" />
@@ -154,103 +207,177 @@ const LeagueManagementPage = () => {
                 <Tab label="Contact Info" value="contacts" />
               </TabList>
             </Box>
-            <TabPanel value="manage">
+
+            <TabPanel value="manage" sx={{ p: { xs: 2, md: 3 } }}>
               <InfoText>
                 Create new seasons and delete seasons that are no longer needed.
               </InfoText>
-              <Typography variant="h7" gutterBottom sx={{ mb: 2 }}>
+              <Typography 
+                variant="h6" 
+                sx={{ 
+                  mb: 3,
+                  color: MCMASTER_COLORS.maroon,
+                  fontWeight: 600
+                }}
+              >
                 Create New Season
               </Typography>
               <CreateSeasonForm seasons={seasons} setSeasons={setSeasons} />
               <SeasonsTable seasons={seasons} setSeasons={setSeasons} />
             </TabPanel>
-            <TabPanel value="upcoming">
+
+            <TabPanel value="upcoming" sx={{ p: { xs: 2, md: 3 } }}>
               <InfoText>
-                Manage and launch seasons that are currently open for
-                registration. Seasons will automatically launch on the start date.
+                Manage and launch seasons that are currently open for registration. 
+                Seasons will automatically launch on the start date.
               </InfoText>
-              {!!upcomingSeasons &&
-                upcomingSeasons.map((season) => (
-                  <Accordion>
-                    <AccordionSummary
-                      expandIcon={<ArrowDropDownIcon />}
-                      id="upcoming-header"
+              {!!upcomingSeasons && upcomingSeasons.map((season) => (
+                <Accordion 
+                  key={season.id}
+                  sx={{
+                    mb: 2,
+                    boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+                    '&:before': { display: 'none' },
+                    '&.Mui-expanded': {
+                      margin: '0 0 16px 0',
+                    }
+                  }}
+                >
+                  <AccordionSummary
+                    expandIcon={<ArrowDropDownIcon />}
+                    sx={{
+                      backgroundColor: 'rgba(122, 0, 60, 0.03)',
+                      '&:hover': {
+                        backgroundColor: 'rgba(122, 0, 60, 0.05)',
+                      }
+                    }}
+                  >
+                    <Typography 
+                      variant="h6"
+                      sx={{ 
+                        color: MCMASTER_COLORS.maroon,
+                        fontWeight: 600,
+                        fontSize: '1.1rem'
+                      }}
                     >
-                      <Typography variant="h5" component="span">
-                        {season.name}
+                      {season.name}
+                    </Typography>
+                  </AccordionSummary>
+                  <AccordionDetails sx={{ p: 3 }}>
+                    <Box sx={{ mb: 3 }}>
+                      <Typography sx={{ mb: 1, color: MCMASTER_COLORS.grey }}>
+                        <strong>Start Date:</strong> {formatDate(season.startDate)}
                       </Typography>
-                    </AccordionSummary>
-                    <AccordionDetails>
-                      <Typography>
-                        Start Date: {formatDate(season.startDate)}
+                      <Typography sx={{ color: MCMASTER_COLORS.grey }}>
+                        <strong>End Date:</strong> {formatDate(season.endDate)}
                       </Typography>
-
-                      <Typography>
-                        End Date: {formatDate(season.endDate)}
-                      </Typography>
-
-                      <TeamSchedulingComponent
-                        // registeredTeamsIds={season.registeredTeams}
-                        season={season}
-                        divisions={season.divisions}
-                        registeredTeams={season.registeredTeams}
-                      />
-                    </AccordionDetails>
-                  </Accordion>
-                ))}
+                    </Box>
+                    <TeamSchedulingComponent
+                      season={season}
+                      divisions={season.divisions}
+                      registeredTeams={season.registeredTeams}
+                    />
+                  </AccordionDetails>
+                </Accordion>
+              ))}
             </TabPanel>
-            <TabPanel value="ongoing">
+
+            <TabPanel value="ongoing" sx={{ p: { xs: 2, md: 3 } }}>
               <InfoText>
-                Input scores and view the schedules and results of ongoing
-                seasons. Seasons will be automatically archived after the end date.
+                Input scores and view the schedules and results of ongoing seasons. 
+                Seasons will be automatically archived after the end date.
               </InfoText>
-
-              {!!ongoingSeasons &&
-                ongoingSeasons.map((season) => (
-                  <Accordion>
-                    <AccordionSummary
-                      expandIcon={<ArrowDropDownIcon />}
-                      id="ongoing-header"
+              {!!ongoingSeasons && ongoingSeasons.map((season) => (
+                <Accordion 
+                  key={season.id}
+                  sx={{
+                    mb: 2,
+                    boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+                    '&:before': { display: 'none' },
+                    '&.Mui-expanded': {
+                      margin: '0 0 16px 0',
+                    }
+                  }}
+                >
+                  <AccordionSummary
+                    expandIcon={<ArrowDropDownIcon />}
+                    sx={{
+                      backgroundColor: 'rgba(122, 0, 60, 0.03)',
+                      '&:hover': {
+                        backgroundColor: 'rgba(122, 0, 60, 0.05)',
+                      }
+                    }}
+                  >
+                    <Typography 
+                      variant="h6"
+                      sx={{ 
+                        color: MCMASTER_COLORS.maroon,
+                        fontWeight: 600,
+                        fontSize: '1.1rem'
+                      }}
                     >
-                      <Typography variant="h5" component="span">
-                        {season.name}
-                      </Typography>
-                    </AccordionSummary>
-                    <AccordionDetails>
-                      <ScheduleTable schedule={season.schedule} />
-                      <Button
-                      
-                        variant="contained"
-                        color="error"
-                        onClick={() => handleArchiveSeason(season.id)}                      >
-                        Archive Season
-                      </Button>
-                    </AccordionDetails>
-                  </Accordion>
-                ))}
+                      {season.name}
+                    </Typography>
+                  </AccordionSummary>
+                  <AccordionDetails sx={{ p: 3 }}>
+                    <ScheduleTable schedule={season.schedule} />
+                    <Button
+                      variant="contained"
+                      color="error"
+                      onClick={() => handleArchiveSeason(season.id)}
+                      sx={{ mt: 3 }}
+                    >
+                      Archive Season
+                    </Button>
+                  </AccordionDetails>
+                </Accordion>
+              ))}
             </TabPanel>
-            <TabPanel value="archived">
+
+            <TabPanel value="archived" sx={{ p: { xs: 2, md: 3 } }}>
               <InfoText>
                 View schedules and results of past archived seasons.
               </InfoText>
-              {!!archivedSeasons &&
-                archivedSeasons.map((season) => (
-                  <Accordion>
-                    <AccordionSummary
-                      expandIcon={<ArrowDropDownIcon />}
-                      id="archived-header"
+              {!!archivedSeasons && archivedSeasons.map((season) => (
+                <Accordion 
+                  key={season.id}
+                  sx={{
+                    mb: 2,
+                    boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+                    '&:before': { display: 'none' },
+                    '&.Mui-expanded': {
+                      margin: '0 0 16px 0',
+                    }
+                  }}
+                >
+                  <AccordionSummary
+                    expandIcon={<ArrowDropDownIcon />}
+                    sx={{
+                      backgroundColor: 'rgba(122, 0, 60, 0.03)',
+                      '&:hover': {
+                        backgroundColor: 'rgba(122, 0, 60, 0.05)',
+                      }
+                    }}
+                  >
+                    <Typography 
+                      variant="h6"
+                      sx={{ 
+                        color: MCMASTER_COLORS.maroon,
+                        fontWeight: 600,
+                        fontSize: '1.1rem'
+                      }}
                     >
-                      <Typography variant="h5" component="span">
-                        {season.name}
-                      </Typography>
-                    </AccordionSummary>
-                    <AccordionDetails>
-                      <ScheduleTable schedule={season.schedule} archived />
-                    </AccordionDetails>
-                  </Accordion>
-                ))}
+                      {season.name}
+                    </Typography>
+                  </AccordionSummary>
+                  <AccordionDetails sx={{ p: 3 }}>
+                    <ScheduleTable schedule={season.schedule} archived />
+                  </AccordionDetails>
+                </Accordion>
+              ))}
             </TabPanel>
-            <TabPanel value="contacts">
+
+            <TabPanel value="contacts" sx={{ p: { xs: 2, md: 3 } }}>
               <InfoText>
                 View contact information for team captains across all seasons.
               </InfoText>
@@ -259,7 +386,7 @@ const LeagueManagementPage = () => {
           </TabContext>
         </Box>
       </Container>
-    </>
+    </Box>
   );
 };
 

--- a/src/frontend/src/views/LeagueManagementPage.jsx
+++ b/src/frontend/src/views/LeagueManagementPage.jsx
@@ -53,13 +53,15 @@ const LeagueManagementPage = () => {
 
   // Component state values
   const [value, setValue] = useState("manage");
-  const handleTabChange = (event, newValue) => {
-    setLoading(true);
+  const [isTabLoading, setIsTabLoading] = useState(false);
 
-    setTimeout(() => {
-      setValue(newValue);
-      setLoading(false);
-    }, 50);
+  const handleTabChange = async (event, newValue) => {
+    setIsTabLoading(true);
+    setValue(newValue);
+    
+    // Give time for loading state to show and data to be prepared
+    await new Promise(resolve => setTimeout(resolve, 100));
+    setIsTabLoading(false);
   };
 
   useEffect(() => {
@@ -175,13 +177,16 @@ const LeagueManagementPage = () => {
           bgcolor: 'white', 
           borderRadius: 2,
           boxShadow: '0 4px 20px rgba(0,0,0,0.08)',
-          overflow: 'hidden'
+          overflow: 'hidden',
+          position: 'relative'
         }}>
           <TabContext value={value}>
             <Box sx={{ 
               borderBottom: 1, 
               borderColor: 'divider',
-              bgcolor: 'white'
+              bgcolor: 'white',
+              position: 'relative',
+              zIndex: 1
             }}>
               <TabList 
                 onChange={handleTabChange}
@@ -193,6 +198,9 @@ const LeagueManagementPage = () => {
                     '&.Mui-selected': {
                       color: MCMASTER_COLORS.maroon,
                       fontWeight: 600
+                    },
+                    '&.Mui-disabled': {
+                      color: `${MCMASTER_COLORS.grey}80`,
                     }
                   },
                   '& .MuiTabs-indicator': {
@@ -200,189 +208,222 @@ const LeagueManagementPage = () => {
                   }
                 }}
               >
-                <Tab label="Manage Seasons" value="manage" />
-                <Tab label="Upcoming Seasons" value="upcoming" />
-                <Tab label="Ongoing Seasons" value="ongoing" />
-                <Tab label="Archived Seasons" value="archived" />
-                <Tab label="Contact Info" value="contacts" />
+                <Tab label="Manage Seasons" value="manage" disabled={isTabLoading} />
+                <Tab label="Upcoming Seasons" value="upcoming" disabled={isTabLoading} />
+                <Tab label="Ongoing Seasons" value="ongoing" disabled={isTabLoading} />
+                <Tab label="Archived Seasons" value="archived" disabled={isTabLoading} />
+                <Tab label="Contact Info" value="contacts" disabled={isTabLoading} />
               </TabList>
             </Box>
-
-            <TabPanel value="manage" sx={{ p: { xs: 2, md: 3 } }}>
-              <InfoText>
-                Create new seasons and delete seasons that are no longer needed.
-              </InfoText>
-              <Typography 
-                variant="h6" 
-                sx={{ 
-                  mb: 3,
-                  color: MCMASTER_COLORS.maroon,
-                  fontWeight: 600
-                }}
-              >
-                Create New Season
-              </Typography>
-              <CreateSeasonForm seasons={seasons} setSeasons={setSeasons} />
-              <SeasonsTable seasons={seasons} setSeasons={setSeasons} />
-            </TabPanel>
-
-            <TabPanel value="upcoming" sx={{ p: { xs: 2, md: 3 } }}>
-              <InfoText>
-                Manage and launch seasons that are currently open for registration. 
-                Seasons will automatically launch on the start date.
-              </InfoText>
-              {!!upcomingSeasons && upcomingSeasons.map((season) => (
-                <Accordion 
-                  key={season.id}
-                  sx={{
-                    mb: 2,
-                    boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
-                    '&:before': { display: 'none' },
-                    '&.Mui-expanded': {
-                      margin: '0 0 16px 0',
-                    }
+            
+            {/* Loading overlay component - AI generated */}
+            <Box sx={{ position: 'relative' }}>
+              {isTabLoading && (
+                <Box 
+                  sx={{ 
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    bgcolor: 'rgba(255, 255, 255, 0.8)',
+                    zIndex: 2,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    minHeight: '200px'
                   }}
                 >
-                  <AccordionSummary
-                    expandIcon={<ArrowDropDownIcon />}
+                  <Typography 
+                    sx={{ 
+                      color: MCMASTER_COLORS.maroon,
+                      fontWeight: 500,
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1
+                    }}
+                  >
+                    Loading...
+                  </Typography>
+                </Box>
+              )}
+
+              <TabPanel value="manage" sx={{ p: { xs: 2, md: 3 } }}>
+                <InfoText>
+                  Create new seasons and delete seasons that are no longer needed.
+                </InfoText>
+                <Typography 
+                  variant="h6" 
+                  sx={{ 
+                    mb: 3,
+                    color: MCMASTER_COLORS.maroon,
+                    fontWeight: 600
+                  }}
+                >
+                  Create New Season
+                </Typography>
+                <CreateSeasonForm seasons={seasons} setSeasons={setSeasons} />
+                <SeasonsTable seasons={seasons} setSeasons={setSeasons} />
+              </TabPanel>
+
+              <TabPanel value="upcoming" sx={{ p: { xs: 2, md: 3 } }}>
+                <InfoText>
+                  Manage and launch seasons that are currently open for registration. 
+                  Seasons will automatically launch on the start date.
+                </InfoText>
+                {!!upcomingSeasons && upcomingSeasons.map((season) => (
+                  <Accordion 
+                    key={season.id}
                     sx={{
-                      backgroundColor: 'rgba(122, 0, 60, 0.03)',
-                      '&:hover': {
-                        backgroundColor: 'rgba(122, 0, 60, 0.05)',
+                      mb: 2,
+                      boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+                      '&:before': { display: 'none' },
+                      '&.Mui-expanded': {
+                        margin: '0 0 16px 0',
                       }
                     }}
                   >
-                    <Typography 
-                      variant="h6"
-                      sx={{ 
-                        color: MCMASTER_COLORS.maroon,
-                        fontWeight: 600,
-                        fontSize: '1.1rem'
+                    <AccordionSummary
+                      expandIcon={<ArrowDropDownIcon />}
+                      sx={{
+                        backgroundColor: 'rgba(122, 0, 60, 0.03)',
+                        '&:hover': {
+                          backgroundColor: 'rgba(122, 0, 60, 0.05)',
+                        }
                       }}
                     >
-                      {season.name}
-                    </Typography>
-                  </AccordionSummary>
-                  <AccordionDetails sx={{ p: 3 }}>
-                    <Box sx={{ mb: 3 }}>
-                      <Typography sx={{ mb: 1, color: MCMASTER_COLORS.grey }}>
-                        <strong>Start Date:</strong> {formatDate(season.startDate)}
+                      <Typography 
+                        variant="h6"
+                        sx={{ 
+                          color: MCMASTER_COLORS.maroon,
+                          fontWeight: 600,
+                          fontSize: '1.1rem'
+                        }}
+                      >
+                        {season.name}
                       </Typography>
-                      <Typography sx={{ color: MCMASTER_COLORS.grey }}>
-                        <strong>End Date:</strong> {formatDate(season.endDate)}
+                    </AccordionSummary>
+                    <AccordionDetails sx={{ p: 3 }}>
+                      <Box sx={{ mb: 3 }}>
+                        <Typography sx={{ mb: 1, color: MCMASTER_COLORS.grey }}>
+                          <strong>Start Date:</strong> {formatDate(season.startDate)}
+                        </Typography>
+                        <Typography sx={{ color: MCMASTER_COLORS.grey }}>
+                          <strong>End Date:</strong> {formatDate(season.endDate)}
+                        </Typography>
+                      </Box>
+                      <TeamSchedulingComponent
+                        season={season}
+                        divisions={season.divisions}
+                        registeredTeams={season.registeredTeams}
+                      />
+                    </AccordionDetails>
+                  </Accordion>
+                ))}
+              </TabPanel>
+
+              <TabPanel value="ongoing" sx={{ p: { xs: 2, md: 3 } }}>
+                <InfoText>
+                  Input scores and view the schedules and results of ongoing seasons. 
+                  Seasons will be automatically archived after the end date.
+                </InfoText>
+                {!!ongoingSeasons && ongoingSeasons.map((season) => (
+                  <Accordion 
+                    key={season.id}
+                    sx={{
+                      mb: 2,
+                      boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+                      '&:before': { display: 'none' },
+                      '&.Mui-expanded': {
+                        margin: '0 0 16px 0',
+                      }
+                    }}
+                  >
+                    <AccordionSummary
+                      expandIcon={<ArrowDropDownIcon />}
+                      sx={{
+                        backgroundColor: 'rgba(122, 0, 60, 0.03)',
+                        '&:hover': {
+                          backgroundColor: 'rgba(122, 0, 60, 0.05)',
+                        }
+                      }}
+                    >
+                      <Typography 
+                        variant="h6"
+                        sx={{ 
+                          color: MCMASTER_COLORS.maroon,
+                          fontWeight: 600,
+                          fontSize: '1.1rem'
+                        }}
+                      >
+                        {season.name}
                       </Typography>
-                    </Box>
-                    <TeamSchedulingComponent
-                      season={season}
-                      divisions={season.divisions}
-                      registeredTeams={season.registeredTeams}
-                    />
-                  </AccordionDetails>
-                </Accordion>
-              ))}
-            </TabPanel>
+                    </AccordionSummary>
+                    <AccordionDetails sx={{ p: 3 }}>
+                      <ScheduleTable schedule={season.schedule} />
+                      <Button
+                        variant="contained"
+                        color="error"
+                        onClick={() => handleArchiveSeason(season.id)}
+                        sx={{ mt: 3 }}
+                      >
+                        Archive Season
+                      </Button>
+                    </AccordionDetails>
+                  </Accordion>
+                ))}
+              </TabPanel>
 
-            <TabPanel value="ongoing" sx={{ p: { xs: 2, md: 3 } }}>
-              <InfoText>
-                Input scores and view the schedules and results of ongoing seasons. 
-                Seasons will be automatically archived after the end date.
-              </InfoText>
-              {!!ongoingSeasons && ongoingSeasons.map((season) => (
-                <Accordion 
-                  key={season.id}
-                  sx={{
-                    mb: 2,
-                    boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
-                    '&:before': { display: 'none' },
-                    '&.Mui-expanded': {
-                      margin: '0 0 16px 0',
-                    }
-                  }}
-                >
-                  <AccordionSummary
-                    expandIcon={<ArrowDropDownIcon />}
+              <TabPanel value="archived" sx={{ p: { xs: 2, md: 3 } }}>
+                <InfoText>
+                  View schedules and results of past archived seasons.
+                </InfoText>
+                {!!archivedSeasons && archivedSeasons.map((season) => (
+                  <Accordion 
+                    key={season.id}
                     sx={{
-                      backgroundColor: 'rgba(122, 0, 60, 0.03)',
-                      '&:hover': {
-                        backgroundColor: 'rgba(122, 0, 60, 0.05)',
+                      mb: 2,
+                      boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+                      '&:before': { display: 'none' },
+                      '&.Mui-expanded': {
+                        margin: '0 0 16px 0',
                       }
                     }}
                   >
-                    <Typography 
-                      variant="h6"
-                      sx={{ 
-                        color: MCMASTER_COLORS.maroon,
-                        fontWeight: 600,
-                        fontSize: '1.1rem'
+                    <AccordionSummary
+                      expandIcon={<ArrowDropDownIcon />}
+                      sx={{
+                        backgroundColor: 'rgba(122, 0, 60, 0.03)',
+                        '&:hover': {
+                          backgroundColor: 'rgba(122, 0, 60, 0.05)',
+                        }
                       }}
                     >
-                      {season.name}
-                    </Typography>
-                  </AccordionSummary>
-                  <AccordionDetails sx={{ p: 3 }}>
-                    <ScheduleTable schedule={season.schedule} />
-                    <Button
-                      variant="contained"
-                      color="error"
-                      onClick={() => handleArchiveSeason(season.id)}
-                      sx={{ mt: 3 }}
-                    >
-                      Archive Season
-                    </Button>
-                  </AccordionDetails>
-                </Accordion>
-              ))}
-            </TabPanel>
+                      <Typography 
+                        variant="h6"
+                        sx={{ 
+                          color: MCMASTER_COLORS.maroon,
+                          fontWeight: 600,
+                          fontSize: '1.1rem'
+                        }}
+                      >
+                        {season.name}
+                      </Typography>
+                    </AccordionSummary>
+                    <AccordionDetails sx={{ p: 3 }}>
+                      <ScheduleTable schedule={season.schedule} archived />
+                    </AccordionDetails>
+                  </Accordion>
+                ))}
+              </TabPanel>
 
-            <TabPanel value="archived" sx={{ p: { xs: 2, md: 3 } }}>
-              <InfoText>
-                View schedules and results of past archived seasons.
-              </InfoText>
-              {!!archivedSeasons && archivedSeasons.map((season) => (
-                <Accordion 
-                  key={season.id}
-                  sx={{
-                    mb: 2,
-                    boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
-                    '&:before': { display: 'none' },
-                    '&.Mui-expanded': {
-                      margin: '0 0 16px 0',
-                    }
-                  }}
-                >
-                  <AccordionSummary
-                    expandIcon={<ArrowDropDownIcon />}
-                    sx={{
-                      backgroundColor: 'rgba(122, 0, 60, 0.03)',
-                      '&:hover': {
-                        backgroundColor: 'rgba(122, 0, 60, 0.05)',
-                      }
-                    }}
-                  >
-                    <Typography 
-                      variant="h6"
-                      sx={{ 
-                        color: MCMASTER_COLORS.maroon,
-                        fontWeight: 600,
-                        fontSize: '1.1rem'
-                      }}
-                    >
-                      {season.name}
-                    </Typography>
-                  </AccordionSummary>
-                  <AccordionDetails sx={{ p: 3 }}>
-                    <ScheduleTable schedule={season.schedule} archived />
-                  </AccordionDetails>
-                </Accordion>
-              ))}
-            </TabPanel>
-
-            <TabPanel value="contacts" sx={{ p: { xs: 2, md: 3 } }}>
-              <InfoText>
-                View contact information for team captains across all seasons.
-              </InfoText>
-              <CommissionerContactInfo seasons={seasons} />
-            </TabPanel>
+              <TabPanel value="contacts" sx={{ p: { xs: 2, md: 3 } }}>
+                <InfoText>
+                  View contact information for team captains across all seasons.
+                </InfoText>
+                <CommissionerContactInfo seasons={seasons} />
+              </TabPanel>
+            </Box>
           </TabContext>
         </Box>
       </Container>

--- a/src/frontend/src/views/MyTeamPage.jsx
+++ b/src/frontend/src/views/MyTeamPage.jsx
@@ -201,7 +201,8 @@ export default function MyTeamPage() {
                       p: 2,
                       bgcolor: 'white',
                       borderRadius: 1,
-                      boxShadow: 1,
+                      //boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+                      border: '1px solid rgba(0,0,0,0.1)',
                       '& .stat-label': {
                         color: MCMASTER_COLOURS.grey,
                         fontWeight: "bold",
@@ -230,6 +231,8 @@ export default function MyTeamPage() {
                       </Typography>
                     </Stack>
                   </Stack>
+
+                  <Divider sx={{ my: 4 }} />
 
                   {/* For captain view */}
                   {(player.team.captainId.id === playerId ||

--- a/src/frontend/src/views/MyTeamPage.jsx
+++ b/src/frontend/src/views/MyTeamPage.jsx
@@ -26,6 +26,14 @@ import { getScheduleGamesByTeamId } from "../api/team";
 import LoadingOverlay from "../components/LoadingOverlay";
 import ContactInfoTable from "../components/ContactInfoTable";
 
+// McMaster colors
+const MCMASTER_COLORS = {
+  maroon: '#7A003C',
+  grey: '#5E6A71',
+  gold: '#FDBF57',
+  lightGrey: '#F5F5F5',
+};
+
 export default function MyTeamPage() {
   const auth = useAuth();
   const { id: teamId } = useParams();
@@ -105,19 +113,45 @@ export default function MyTeamPage() {
   }, [player, teamTabValue]);
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div 
+      style={{ 
+        backgroundColor: MCMASTER_COLORS.lightGrey,
+        minHeight: '100vh',
+        height: '100%',
+        position: 'fixed',
+        width: '100%',
+        overflowY: 'auto'
+      }}
+    >
       <NavBar />
       <Container maxWidth="lg" sx={{ py: 4 }}>
+        <Typography 
+          variant="h4" 
+          sx={{ 
+            fontWeight: "bold",
+            mb: 3
+          }}
+        >
+          My Team
+        </Typography>
+
         {loading ? (
           <LoadingOverlay loading={loading} />
         ) : player && player.team ? (
           <>
-            <Typography variant="h4" fontWeight="bold">
-              Teams
-            </Typography>
             <TabContext value={teamTabValue}>
               <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
-                <TabList onChange={handleChange}>
+                <TabList 
+                  onChange={handleChange}
+                  sx={{
+                    '& .Mui-selected': {
+                      color: `${MCMASTER_COLORS.maroon} !important`,
+                    },
+                    '& .MuiTabs-indicator': {
+                      backgroundColor: MCMASTER_COLORS.maroon,
+                    }
+                  }}
+                >
                   <Tab label={player.team.name} value={player.team.id} />
                   {(player.team.captainId.id === playerId ||
                     player.role === "commissioner") && (
@@ -126,74 +160,84 @@ export default function MyTeamPage() {
                 </TabList>
               </Box>
 
-              {/* Team Panel */}
               <TabPanel value={player.team.id}>
                 <Box>
-                  <Typography variant="h4" component="h1" gutterBottom>
-                    <span style={{ color: "#7A003C", fontWeight: "bold" }}>
-                      {player.team.name}
-                    </span>
+                  <Typography 
+                    variant="h4" 
+                    component="h1" 
+                    sx={{ 
+                      color: MCMASTER_COLORS.maroon,
+                      fontWeight: "bold",
+                      fontSize: { xs: "2.5rem", md: "3rem" },
+                      mb: 1,
+                      display: 'flex',
+                      alignItems: 'baseline',
+                      gap: 1
+                    }}
+                  >
+                    {player.team.name}
                     {player.team.captainId.id === playerId && (
-                      <span
-                        style={{
-                          color: "gray",
+                      <Typography
+                        component="span"
+                        sx={{
+                          ml: 1,
+                          color: MCMASTER_COLORS.grey,
                           fontWeight: "normal",
                           fontSize: "0.8em",
                         }}
                       >
-                        {" "}
                         (captain)
-                      </span>
+                      </Typography>
                     )}
                   </Typography>
-                  <Stack direction="row" spacing={3} mb={2} alignItems="center">
+
+                  <Stack 
+                    direction="row" 
+                    spacing={4} 
+                    mb={4}
+                    mt={2}
+                    sx={{ 
+                      p: 2,
+                      bgcolor: 'white',
+                      borderRadius: 1,
+                      boxShadow: 1,
+                      '& .stat-label': {
+                        color: MCMASTER_COLORS.grey,
+                        fontWeight: "bold",
+                        fontSize: '1.1rem',
+                      },
+                      '& .stat-value': {
+                        fontSize: '1.1rem',
+                        fontWeight: 500,
+                      }
+                    }}
+                  >
                     <Stack direction="row" spacing={1} alignItems="center">
-                      <Typography
-                        variant="h6"
-                        sx={{ fontWeight: "bold", color: "#495965" }}
-                      >
-                        Season:
-                      </Typography>
-                      <Typography variant="h6">
-                        {player.team.seasonId.name}
-                      </Typography>
+                      <Typography className="stat-label">Season:</Typography>
+                      <Typography className="stat-value">{player.team.seasonId.name}</Typography>
                     </Stack>
 
                     <Stack direction="row" spacing={1} alignItems="center">
-                      <Typography
-                        variant="h6"
-                        sx={{ fontWeight: "bold", color: "#495965" }}
-                      >
-                        Division:
-                      </Typography>
-                      <Typography variant="h6">
-                        {player.team.divisionId.name}
-                      </Typography>
+                      <Typography className="stat-label">Division:</Typography>
+                      <Typography className="stat-value">{player.team.divisionId.name}</Typography>
                     </Stack>
 
                     <Stack direction="row" spacing={1} alignItems="center">
-                      <Typography
-                        variant="h6"
-                        sx={{ fontWeight: "bold", color: "#495965" }}
-                      >
-                        Record (W/D/L):
-                      </Typography>
-                      <Typography variant="h6">
-                        {player.team.wins}-{player.team.draws}-
-                        {player.team.losses}
+                      <Typography className="stat-label">Record (W/D/L):</Typography>
+                      <Typography className="stat-value">
+                        {player.team.wins}-{player.team.draws}-{player.team.losses}
                       </Typography>
                     </Stack>
                   </Stack>
-                  <Divider sx={{ my: 4 }} />
 
                   {/* For captain view */}
                   {(player.team.captainId.id === playerId ||
                     player.role === "commissioner") && (
                     <>
                       <Typography
-                        variant="subtitle2"
+                        variant="h5"
                         sx={{
-                          fontSize: { xs: "2rem", md: "2rem" },
+                          fontSize: "2rem",
                           fontWeight: 700,
                           mb: 2,
                         }}
@@ -210,9 +254,9 @@ export default function MyTeamPage() {
                   )}
 
                   <Typography
-                    variant="subtitle2"
+                    variant="h5"
                     sx={{
-                      fontSize: { xs: "2rem", md: "2rem" },
+                      fontSize: "2rem",
                       fontWeight: 700,
                       mb: 2,
                     }}
@@ -228,41 +272,40 @@ export default function MyTeamPage() {
                       variant="contained"
                       size="small"
                       sx={{
-                        bgcolor: "#800020",
+                        bgcolor: MCMASTER_COLORS.maroon,
                         mt: 1,
                         mb: 2,
+                        '&:hover': {
+                          bgcolor: '#5A002C',
+                        }
                       }}
                       onClick={() => navigate("/players")}
                     >
                       Invite Players
                     </Button>
                   )}
-                  {player.team.captainId.id === playerId && (
-                    <>
-                      <Divider sx={{ my: 4 }} />
+                  <Divider sx={{ my: 4 }} />
 
-                      <Typography
-                        variant="subtitle2"
-                        sx={{
-                          fontSize: { xs: "2rem", md: "2rem" },
-                          fontWeight: 700,
-                          mb: 2,
-                        }}
-                      >
-                        Submit Game Scores
-                      </Typography>
-                      {teamGames && teamGames.games && teamGames.games.length > 0 ? (
-                        <ScheduleTable
-                          schedule={teamGames}
-                          captain={player.team.captainId.id}
-                          player={playerId}
-                          role={player.role}
-                          archived={teamGames.archived}
-                        />
-                      ) : (
-                        <NoDataCard text="No schedule to show." />
-                      )}
-                    </>
+                  <Typography
+                    variant="h5"
+                    sx={{
+                      fontSize: "2rem",
+                      fontWeight: 700,
+                      mb: 2,
+                    }}
+                  >
+                    Team Schedule
+                  </Typography>
+                  {teamGames && teamGames.games && teamGames.games.length > 0 ? (
+                    <ScheduleTable
+                      schedule={teamGames}
+                      captain={player.team.captainId.id}
+                      player={playerId}
+                      role={player.role}
+                      archived={teamGames.archived}
+                    />
+                  ) : (
+                    <NoDataCard text="No schedule to show." />
                   )}
                 </Box>
               </TabPanel>
@@ -270,7 +313,15 @@ export default function MyTeamPage() {
               {/* Contacts Panel */}
               <TabPanel value="contacts">
                 <Box>
-                  <Typography variant="h4" component="h2" gutterBottom>
+                  <Typography 
+                    variant="h4" 
+                    component="h2" 
+                    sx={{ 
+                      color: MCMASTER_COLORS.maroon,
+                      fontWeight: "bold",
+                      mb: 2
+                    }}
+                  >
                     Captain Contact Information
                   </Typography>
                   <ContactInfoTable
@@ -284,7 +335,6 @@ export default function MyTeamPage() {
           </>
         ) : (
           <Box>            
-            {/* Only show Team Invitations when player has no team */}
             <Typography variant="subtitle2" sx={{
               fontSize: { xs: "2rem", md: "2rem" },
               fontWeight: 700,

--- a/src/frontend/src/views/MyTeamPage.jsx
+++ b/src/frontend/src/views/MyTeamPage.jsx
@@ -128,7 +128,7 @@ export default function MyTeamPage() {
         <Typography 
           variant="h4" 
           sx={{ 
-            fontWeight: "bold",
+            fontWeight: 700,
             mb: 3
           }}
         >
@@ -168,7 +168,7 @@ export default function MyTeamPage() {
                     component="h1" 
                     sx={{ 
                       color: MCMASTER_COLOURS.maroon,
-                      fontWeight: "bold",
+                      fontWeight: 700,
                       fontSize: { xs: "2.5rem", md: "3rem" },
                       mb: 1,
                       display: 'flex',
@@ -265,6 +265,30 @@ export default function MyTeamPage() {
                       mb: 2,
                     }}
                   >
+                    Team Schedule
+                  </Typography>
+                  {teamGames && teamGames.games && teamGames.games.length > 0 ? (
+                    <ScheduleTable
+                      schedule={teamGames}
+                      captain={player.team.captainId.id}
+                      player={playerId}
+                      role={player.role}
+                      archived={teamGames.archived}
+                    />
+                  ) : (
+                    <NoDataCard text="No schedule to show." />
+                  )}
+
+                  <Divider sx={{ my: 6 }} />
+
+                  <Typography
+                    variant="h5"
+                    sx={{
+                      fontSize: "2rem",
+                      fontWeight: 700,
+                      mb: 2,
+                    }}
+                  >
                     Roster
                   </Typography>
                   <RosterTable
@@ -288,29 +312,8 @@ export default function MyTeamPage() {
                       Invite Players
                     </Button>
                   )}
-                  <Divider sx={{ my: 4 }} />
+                  
 
-                  <Typography
-                    variant="h5"
-                    sx={{
-                      fontSize: "2rem",
-                      fontWeight: 700,
-                      mb: 2,
-                    }}
-                  >
-                    Team Schedule
-                  </Typography>
-                  {teamGames && teamGames.games && teamGames.games.length > 0 ? (
-                    <ScheduleTable
-                      schedule={teamGames}
-                      captain={player.team.captainId.id}
-                      player={playerId}
-                      role={player.role}
-                      archived={teamGames.archived}
-                    />
-                  ) : (
-                    <NoDataCard text="No schedule to show." />
-                  )}
                 </Box>
               </TabPanel>
 

--- a/src/frontend/src/views/MyTeamPage.jsx
+++ b/src/frontend/src/views/MyTeamPage.jsx
@@ -26,8 +26,8 @@ import { getScheduleGamesByTeamId } from "../api/team";
 import LoadingOverlay from "../components/LoadingOverlay";
 import ContactInfoTable from "../components/ContactInfoTable";
 
-// McMaster colors
-const MCMASTER_COLORS = {
+// McMaster colours - AI Generated
+const MCMASTER_COLOURS = {
   maroon: '#7A003C',
   grey: '#5E6A71',
   gold: '#FDBF57',
@@ -115,7 +115,7 @@ export default function MyTeamPage() {
   return (
     <div 
       style={{ 
-        backgroundColor: MCMASTER_COLORS.lightGrey,
+        backgroundColor: MCMASTER_COLOURS.lightGrey,
         minHeight: '100vh',
         height: '100%',
         position: 'fixed',
@@ -140,15 +140,16 @@ export default function MyTeamPage() {
         ) : player && player.team ? (
           <>
             <TabContext value={teamTabValue}>
+              {/* AI Generated - Tab styling and structure */}
               <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
                 <TabList 
                   onChange={handleChange}
                   sx={{
                     '& .Mui-selected': {
-                      color: `${MCMASTER_COLORS.maroon} !important`,
+                      color: `${MCMASTER_COLOURS.maroon} !important`,
                     },
                     '& .MuiTabs-indicator': {
-                      backgroundColor: MCMASTER_COLORS.maroon,
+                      backgroundColor: MCMASTER_COLOURS.maroon,
                     }
                   }}
                 >
@@ -166,7 +167,7 @@ export default function MyTeamPage() {
                     variant="h4" 
                     component="h1" 
                     sx={{ 
-                      color: MCMASTER_COLORS.maroon,
+                      color: MCMASTER_COLOURS.maroon,
                       fontWeight: "bold",
                       fontSize: { xs: "2.5rem", md: "3rem" },
                       mb: 1,
@@ -181,7 +182,7 @@ export default function MyTeamPage() {
                         component="span"
                         sx={{
                           ml: 1,
-                          color: MCMASTER_COLORS.grey,
+                          color: MCMASTER_COLOURS.grey,
                           fontWeight: "normal",
                           fontSize: "0.8em",
                         }}
@@ -202,7 +203,7 @@ export default function MyTeamPage() {
                       borderRadius: 1,
                       boxShadow: 1,
                       '& .stat-label': {
-                        color: MCMASTER_COLORS.grey,
+                        color: MCMASTER_COLOURS.grey,
                         fontWeight: "bold",
                         fontSize: '1.1rem',
                       },
@@ -272,7 +273,7 @@ export default function MyTeamPage() {
                       variant="contained"
                       size="small"
                       sx={{
-                        bgcolor: MCMASTER_COLORS.maroon,
+                        bgcolor: MCMASTER_COLOURS.maroon,
                         mt: 1,
                         mb: 2,
                         '&:hover': {
@@ -317,7 +318,7 @@ export default function MyTeamPage() {
                     variant="h4" 
                     component="h2" 
                     sx={{ 
-                      color: MCMASTER_COLORS.maroon,
+                      color: MCMASTER_COLOURS.maroon,
                       fontWeight: "bold",
                       mb: 2
                     }}

--- a/src/frontend/src/views/MyTeamPage.jsx
+++ b/src/frontend/src/views/MyTeamPage.jsx
@@ -140,26 +140,25 @@ export default function MyTeamPage() {
         ) : player && player.team ? (
           <>
             <TabContext value={teamTabValue}>
-              {/* AI Generated - Tab styling and structure */}
-              <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
-                <TabList 
-                  onChange={handleChange}
-                  sx={{
-                    '& .Mui-selected': {
-                      color: `${MCMASTER_COLOURS.maroon} !important`,
-                    },
-                    '& .MuiTabs-indicator': {
-                      backgroundColor: MCMASTER_COLOURS.maroon,
-                    }
-                  }}
-                >
-                  <Tab label={player.team.name} value={player.team.id} />
-                  {(player.team.captainId.id === playerId ||
-                    player.role === "commissioner") && (
+              {player.team.captainId.id === playerId && ( // Only show tabs for captains
+                <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+                  {/* AI Generated - Tablist styling */}
+                  <TabList 
+                    onChange={handleChange}
+                    sx={{
+                      '& .Mui-selected': {
+                        color: `${MCMASTER_COLOURS.maroon} !important`,
+                      },
+                      '& .MuiTabs-indicator': {
+                        backgroundColor: MCMASTER_COLOURS.maroon,
+                      }
+                    }}
+                  >
+                    <Tab label={player.team.name} value={player.team.id} />
                     <Tab label="Captain Contacts" value="contacts" />
-                  )}
-                </TabList>
-              </Box>
+                  </TabList>
+                </Box>
+              )}
 
               <TabPanel value={player.team.id}>
                 <Box>
@@ -246,7 +245,7 @@ export default function MyTeamPage() {
                           mb: 2,
                         }}
                       >
-                        Notifications
+                        Scheduling Notifications
                       </Typography>
                       {teamNotifications && teamNotifications.length > 0 ? (
                         <NotificationsRow notifications={teamNotifications} />
@@ -318,26 +317,29 @@ export default function MyTeamPage() {
               </TabPanel>
 
               {/* Contacts Panel */}
-              <TabPanel value="contacts">
-                <Box>
-                  <Typography 
-                    variant="h4" 
-                    component="h2" 
-                    sx={{ 
-                      color: MCMASTER_COLOURS.maroon,
-                      fontWeight: "bold",
-                      mb: 2
-                    }}
-                  >
-                    Captain Contact Information
-                  </Typography>
-                  <ContactInfoTable
-                    currentSeasonId={
-                      player?.team?.seasonId?._id || player?.team?.seasonId
-                    }
-                  />
-                </Box>
-              </TabPanel>
+              {/* AI Generated - contacts panel styling */}
+              {player.team.captainId.id === playerId && ( // Only show contacts panel for captains
+                <TabPanel value="contacts">
+                  <Box>
+                    <Typography 
+                      variant="h4" 
+                      component="h2" 
+                      sx={{ 
+                        color: MCMASTER_COLOURS.maroon,
+                        fontWeight: "bold",
+                        mb: 2
+                      }}
+                    >
+                      Captain Contact Information
+                    </Typography>
+                    <ContactInfoTable
+                      currentSeasonId={
+                        player?.team?.seasonId?._id || player?.team?.seasonId
+                      }
+                    />
+                  </Box>
+                </TabPanel>
+              )}
             </TabContext>
           </>
         ) : (

--- a/src/frontend/src/views/ProfilePage.jsx
+++ b/src/frontend/src/views/ProfilePage.jsx
@@ -12,10 +12,6 @@ import {
   Grid,
   TextField,
   Avatar,
-  List,
-  ListItem,
-  ListItemText,
-  ListItemAvatar,
   Button,
   MenuItem,
 } from "@mui/material";
@@ -32,7 +28,6 @@ const ProfileContainer = styled(Box)(({ theme }) => ({
 
 export default function ProfilePage() {
   const auth = useAuth();
-  const [rerenderTrigger, setRerenderTrigger] = useState(0);
 
   // placeholder profile
   const [player, setPlayer] = useState({
@@ -79,34 +74,6 @@ export default function ProfilePage() {
       [e.target.name]: e.target.value,
     }));
   };  
-
-  const handleAcceptInvite = (teamId) => {
-
-    // Immediate state change before API call
-    setPlayer((prevPlayer) => ({
-      ...prevPlayer,
-      invites: prevPlayer.invites.filter((invite) => invite !== teamId),
-    }));
-
-    // Trigger re-render manually
-    setRerenderTrigger((prev) => prev + 1);
-
-    const requestBody = {
-      playerId: auth.playerId,
-      teamId: teamId,
-    };
-    try {
-      acceptInvite(requestBody);
-    } catch (err) {
-      console.log("Failed to accept team invite");
-
-      //Handle failure (revert the state if needed)
-      setPlayer((prevPlayer) => ({
-        ...prevPlayer,
-        invites: [...prevPlayer.invites, teamId],
-      }));
-    }
-  };
 
   return (
     <>
@@ -270,57 +237,6 @@ export default function ProfilePage() {
                 </Grid>
               </Grid>
             </Box>
-
-            {/* My Teams + Notifications */}
-            <Grid container spacing={4} sx={{ mt: 4 }}>
-              <Grid item xs={12} md={6}>
-                <Typography variant="h6" sx={{ mb: 2 }}>
-                  My Teams
-                </Typography>
-                <List>
-                  {player && player.team && (
-                    <ListItem>
-                      <ListItemAvatar>
-                        <Avatar
-                          src={player.team.name}
-                          alt={player.team.name}
-                          sx={{ width: 35, height: 35, bgcolor: "#7A003C" }}
-                        >
-                          {player.team.name.charAt(0)}
-                        </Avatar>
-                      </ListItemAvatar>
-                      <ListItemText primary={player.team.name} />
-                    </ListItem>
-                  )}
-                </List>
-              </Grid>
-              <Grid item xs={12} md={6}>
-                <Typography variant="h6" sx={{ mb: 2 }}>
-                  Team Invites
-                </Typography>
-                <List disablePadding>
-                  {player.invites?.map((team, index) => (
-                    <ListItem
-                      key={team.id}
-                      secondaryAction={
-                        <>
-                          <Button
-                            color="success"
-                            onClick={() => handleAcceptInvite(team.id)}
-                            sx={{ mr: 1 }}
-                          >
-                            Accept
-                          </Button>
-                          {/* <Button color="error" onClick={() => handleDeclineInvite(team)}>Decline</Button> */}
-                        </>
-                      }
-                    >
-                      <ListItemText primary={team.name} />
-                    </ListItem>
-                  ))}
-                </List>
-              </Grid>
-            </Grid>
           </ProfileContainer>
         </Container>
       </Box>

--- a/src/frontend/src/views/StandingsPage.jsx
+++ b/src/frontend/src/views/StandingsPage.jsx
@@ -8,6 +8,7 @@ import {
   MenuItem,
   FormControl,
   Box,
+  InputLabel,
 } from "@mui/material";
 import NavBar from "../components/NavBar";
 import StandingsTable from "../components/StandingsTable";
@@ -64,7 +65,10 @@ export default function StandingsPage() {
           <Box>
             {/* Season Dropdown */}
             <FormControl sx={{ minWidth: 180, m: 2 }}>
+              <InputLabel id="season-select-label">Season</InputLabel>
               <Select
+                labelId="season-select-label"
+                label="Season"
                 value={selectedSeason}
                 onChange={(e) => {
                   const seasonId = e.target.value;
@@ -78,7 +82,7 @@ export default function StandingsPage() {
               >
                 {seasons.map((season) => (
                   <MenuItem key={season._id} value={season._id}>
-                    {season.name}
+                    {season.name} {season.status === "archived" ? " (Archived)" : ""}
                   </MenuItem>
                 ))}
               </Select>
@@ -86,7 +90,10 @@ export default function StandingsPage() {
 
             {/* Division Dropdown */}
             <FormControl sx={{ minWidth: 180, m: 2 }}>
+              <InputLabel id="division-select-label">Division</InputLabel>
               <Select
+                labelId="division-select-label"
+                label="Division"
                 value={selectedDivision}
                 onChange={(e) => setSelectedDivision(e.target.value)}
               >

--- a/src/frontend/src/views/StandingsPage.jsx
+++ b/src/frontend/src/views/StandingsPage.jsx
@@ -9,9 +9,18 @@ import {
   FormControl,
   Box,
   InputLabel,
+  Stack,
 } from "@mui/material";
 import NavBar from "../components/NavBar";
 import StandingsTable from "../components/StandingsTable";
+
+// McMaster colours - AI generated
+const MCMASTER_COLOURS = {
+  maroon: '#7A003C',
+  grey: '#5E6A71',
+  gold: '#FDBF57',
+  lightGrey: '#F5F5F5',
+};
 
 export default function StandingsPage() {
   const [seasons, setSeasons] = useState([]);
@@ -66,69 +75,142 @@ export default function StandingsPage() {
           minHeight: "100vh",
           display: "flex",
           flexDirection: "column",
+          bgcolor: "#f5f5f5",
         }}
       >
         <Container sx={{ py: 4, flexGrow: 1 }}>
-        <Typography variant="h4" fontWeight="bold" gutterBottom >
-          Standings
-        </Typography>
-          {/* Season & Division Selectors */}
-          <Box>
-            {/* Season Dropdown */}
-            <FormControl sx={{ minWidth: 180, m: 2 }}>
-              <InputLabel id="season-select-label">Season</InputLabel>
-              <Select
-                labelId="season-select-label"
-                label="Season"
-                value={selectedSeason}
-                onChange={(e) => {
-                  const seasonId = e.target.value;
-                  setSelectedSeason(seasonId);
-                  
-                  // Find selected season and update divisions
-                  const selected = seasons.find((s) => s._id === seasonId);
-                  setDivisions(selected?.divisions || []);
-                  setSelectedDivision(selected?.divisions[0]?._id || "");
-                }}
-              >
-                {seasons.map((season) => (
-                  <MenuItem key={season._id} value={season._id}>
-                    {season.name} {season.status === "archived" ? " (Archived)" : ""}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+          <Box
+            sx={{
+              bgcolor: 'white',
+              borderRadius: 2,
+              boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+              border: '1px solid rgba(0,0,0,0.1)',
+              p: 3,
+            }}
+          >
+            <Typography 
+              variant="h4" 
+              sx={{ 
+                fontWeight: "bold",
+                color: MCMASTER_COLOURS.maroon,
+                mb: 3
+              }}
+            >
+              Standings
+            </Typography>
 
-            {/* Division Dropdown */}
-            <FormControl sx={{ minWidth: 180, m: 2 }}>
-              <InputLabel id="division-select-label">Division</InputLabel>
-              <Select
-                labelId="division-select-label"
-                label="Division"
-                value={selectedDivision}
-                onChange={(e) => setSelectedDivision(e.target.value)}
-              >
-                {divisions.map((division) => (
-                  <MenuItem key={division._id} value={division._id}>
-                    {division.name}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            {/* Season & Division Selectors - styling AI generated*/}
+            <Stack 
+              direction={{ xs: 'column', sm: 'row' }} 
+              spacing={2} 
+              sx={{ 
+                mb: 4,
+                '& .MuiFormControl-root': {
+                  minWidth: { xs: '100%', sm: 220 },
+                  '& .MuiOutlinedInput-root': {
+                    '&:hover fieldset': {
+                      borderColor: MCMASTER_COLOURS.maroon,
+                    },
+                    '&.Mui-focused fieldset': {
+                      borderColor: MCMASTER_COLOURS.maroon,
+                    }
+                  },
+                  '& .MuiInputLabel-root.Mui-focused': {
+                    color: MCMASTER_COLOURS.maroon,
+                  }
+                }
+              }}
+            >
+              {/* Season Dropdown */}
+              <FormControl>
+                <InputLabel id="season-select-label">Season</InputLabel>
+                <Select
+                  labelId="season-select-label"
+                  label="Season"
+                  value={selectedSeason}
+                  onChange={(e) => {
+                    const seasonId = e.target.value;
+                    setSelectedSeason(seasonId);
+                    
+                    // Find selected season and update divisions
+                    const selected = seasons.find((s) => s._id === seasonId);
+                    setDivisions(selected?.divisions || []);
+                    setSelectedDivision(selected?.divisions[0]?._id || "");
+                  }}
+                  sx={{
+                    backgroundColor: 'white',
+                  }}
+                >
+                  {seasons.map((season) => (
+                    <MenuItem 
+                      key={season._id} 
+                      value={season._id}
+                      sx={{
+                        '&.Mui-selected': {
+                          backgroundColor: `${MCMASTER_COLOURS.lightGrey}`,
+                          '&:hover': {
+                            backgroundColor: `${MCMASTER_COLOURS.lightGrey}`,
+                          }
+                        },
+                        '&:hover': {
+                          backgroundColor: `${MCMASTER_COLOURS.lightGrey}`,
+                        }
+                      }}
+                    >
+                      {season.name} {season.status === "archived" ? " (Archived)" : ""}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+
+              {/* Division Dropdown */}
+              <FormControl>
+                <InputLabel id="division-select-label">Division</InputLabel>
+                <Select
+                  labelId="division-select-label"
+                  label="Division"
+                  value={selectedDivision}
+                  onChange={(e) => setSelectedDivision(e.target.value)}
+                  sx={{
+                    backgroundColor: 'white',
+                  }}
+                >
+                  {divisions.map((division) => (
+                    <MenuItem 
+                      key={division._id} 
+                      value={division._id}
+                      sx={{
+                        '&.Mui-selected': {
+                          backgroundColor: `${MCMASTER_COLOURS.lightGrey}`,
+                          '&:hover': {
+                            backgroundColor: `${MCMASTER_COLOURS.lightGrey}`,
+                          }
+                        },
+                        '&:hover': {
+                          backgroundColor: `${MCMASTER_COLOURS.lightGrey}`,
+                        }
+                      }}
+                    >
+                      {division.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Stack>
+
+            {/* Standings Table */}
+            <StandingsTable standings={standings} />
+
+            {/* Footnotes */}
+            <Stack spacing={1} sx={{ mt: 3 }}>
+              <Typography variant="body2" color={MCMASTER_COLOURS.grey}>
+                - Points are awarded as follows: 2 points for a win, 1 point for a draw, 0 points for a loss.
+              </Typography>
+              <Typography variant="body2" color={MCMASTER_COLOURS.grey}>
+                - PTS - Points, W - Wins, D - Draws, L - Losses, RS - Runs Scored, RA - Runs Allowed, Run Diff - Run Differential.
+              </Typography>
+            </Stack>
           </Box>
-
-          {/* Standings Table */}
-          <StandingsTable standings={standings} />
-
-          {/* Footnotes */}
-          <Typography variant="body2" color="textSecondary" sx={{ mt: 2 }}>
-            - Points are awarded as follows: 2 points for a win, 1 point for a
-            draw, 0 points for a loss.
-          </Typography>
-          <Typography variant="body2" color="textSecondary" sx={{ mt: 1 }}>
-            - PTS - Points, W - Wins, D - Draws, L - Losses, RS - Runs Scored,
-            RA - Runs Allowed, Run Diff - Run Differential.
-          </Typography>
         </Container>
       </Box>
     </div>

--- a/src/frontend/src/views/StandingsPage.jsx
+++ b/src/frontend/src/views/StandingsPage.jsx
@@ -147,13 +147,13 @@ export default function StandingsPage() {
                       value={season._id}
                       sx={{
                         '&.Mui-selected': {
-                          backgroundColor: `${MCMASTER_COLOURS.lightGrey}`,
+                          backgroundColor: `${MCMASTER_COLOURS.maroon}14`,
                           '&:hover': {
-                            backgroundColor: `${MCMASTER_COLOURS.lightGrey}`,
+                            backgroundColor: `${MCMASTER_COLOURS.maroon}20`,
                           }
                         },
                         '&:hover': {
-                          backgroundColor: `${MCMASTER_COLOURS.lightGrey}`,
+                          backgroundColor: `${MCMASTER_COLOURS.maroon}0A`,
                         }
                       }}
                     >
@@ -181,13 +181,13 @@ export default function StandingsPage() {
                       value={division._id}
                       sx={{
                         '&.Mui-selected': {
-                          backgroundColor: `${MCMASTER_COLOURS.lightGrey}`,
+                          backgroundColor: `${MCMASTER_COLOURS.maroon}14`,
                           '&:hover': {
-                            backgroundColor: `${MCMASTER_COLOURS.lightGrey}`,
+                            backgroundColor: `${MCMASTER_COLOURS.maroon}20`,
                           }
                         },
                         '&:hover': {
-                          backgroundColor: `${MCMASTER_COLOURS.lightGrey}`,
+                          backgroundColor: `${MCMASTER_COLOURS.maroon}0A`,
                         }
                       }}
                     >

--- a/src/frontend/src/views/StandingsPage.jsx
+++ b/src/frontend/src/views/StandingsPage.jsx
@@ -198,19 +198,27 @@ export default function StandingsPage() {
               </FormControl>
             </Stack>
 
-            {/* Standings Table */}
-            <StandingsTable standings={standings} />
+          {/* Standings Table */}
+          {standings.length > 0 ? (
+            <Box>
+              <StandingsTable standings={standings} />
 
-            {/* Footnotes */}
-            <Stack spacing={1} sx={{ mt: 3 }}>
-              <Typography variant="body2" color={MCMASTER_COLOURS.grey}>
-                - Points are awarded as follows: 2 points for a win, 1 point for a draw, 0 points for a loss.
+              {/* Footnotes */}
+              <Typography variant="body2" color="textSecondary" sx={{ mt: 2 }}>
+                - Points are awarded as follows: 2 points for a win, 1 point for a
+                draw, 0 points for a loss.
               </Typography>
-              <Typography variant="body2" color={MCMASTER_COLOURS.grey}>
-                - PTS - Points, W - Wins, D - Draws, L - Losses, RS - Runs Scored, RA - Runs Allowed, Run Diff - Run Differential.
+              <Typography variant="body2" color="textSecondary" sx={{ mt: 1 }}>
+                - PTS - Points, W - Wins, D - Draws, L - Losses, RS - Runs Scored,
+                RA - Runs Allowed, Run Diff - Run Differential.
               </Typography>
-            </Stack>
-          </Box>
+            </Box>
+            ) : (
+            <Typography variant="body1" color="textSecondary" sx={{ mt: 2 }} align='center'>
+              No teams in division
+            </Typography>
+          )}
+          </Box> 
         </Container>
       </Box>
     </div>


### PR DESCRIPTION
Stuff I want to point out:

MyTeamPage:
- The top tabs (team/contacts) only show for captains
- I swapped roster and team schedule cuz I figure that's the more in demand feature when ppl visit the page

that's all I can recall rn thats worth mentioning

![image](https://github.com/user-attachments/assets/09b5f935-5310-418e-9803-33f4d8d4c86e)
![image](https://github.com/user-attachments/assets/3ac687c7-131e-4e10-adc2-379c712d2c8a)
![image](https://github.com/user-attachments/assets/eb8c20e7-e0f3-437f-9858-c4ef3cfb3fb7)
![image](https://github.com/user-attachments/assets/89fdc641-53cf-44a5-9e93-5385c0b34ddf)
![image](https://github.com/user-attachments/assets/62cfd987-9564-4b83-a2af-2dad1e73b808)
![image](https://github.com/user-attachments/assets/80be6ff0-1791-45cc-b87f-4ff05a2e458c)
![image](https://github.com/user-attachments/assets/09ceae90-e120-434f-aa15-bac7734d94d3)
![image](https://github.com/user-attachments/assets/a84121d3-0e33-4ccc-a3be-bf49a4b57d94)
![image](https://github.com/user-attachments/assets/79f1eb3b-d240-499a-9295-6c6376f27072)
![image](https://github.com/user-attachments/assets/23f4abc6-019e-4f0d-b8e4-cdd38ce8c61e)
![image](https://github.com/user-attachments/assets/8137aae4-9faf-42b0-9ae2-9597a539720e)
